### PR TITLE
initial remove all default overrides from libs, use more shared share…

### DIFF
--- a/.hintrc
+++ b/.hintrc
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "development"
+  ],
+  "hints": {
+    "typescript-config/consistent-casing": "off" // is default setting
+  }
+}

--- a/envirometrics/korschenbroich/rainhazardmap/tsconfig.json
+++ b/envirometrics/korschenbroich/rainhazardmap/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "allowJs": false,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
     "types": ["vite/client", "vitest"]
   },
   "files": [],

--- a/envirometrics/wuppertal/floodingmap/tsconfig.json
+++ b/envirometrics/wuppertal/floodingmap/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "allowJs": false,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
+    "noImplicitAny": false,
     "types": ["vite/client", "vitest"]
   },
   "files": [],

--- a/envirometrics/wuppertal/rainhazardmap/tsconfig.json
+++ b/envirometrics/wuppertal/rainhazardmap/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "allowJs": false,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
+    "noImplicitAny": false,
     "types": ["vite/client", "vitest"]
   },
   "files": [],

--- a/libraries/appframeworks/envirometrics/tsconfig.json
+++ b/libraries/appframeworks/envirometrics/tsconfig.json
@@ -1,14 +1,6 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
-  },
+
   "files": [],
   "include": [],
   "references": [

--- a/libraries/appframeworks/envirometrics/tsconfig.lib.json
+++ b/libraries/appframeworks/envirometrics/tsconfig.lib.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "declaration": true,
     "types": ["node", "vite/client"]
   },
   "include": ["src/**/*.ts"],

--- a/libraries/appframeworks/portals/tsconfig.json
+++ b/libraries/appframeworks/portals/tsconfig.json
@@ -1,14 +1,6 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
-  },
+
   "files": [],
   "include": [],
   "references": [

--- a/libraries/appframeworks/portals/tsconfig.lib.json
+++ b/libraries/appframeworks/portals/tsconfig.lib.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "declaration": true,
     "types": ["node", "vite/client"]
   },
   "include": ["src/**/*.ts"],

--- a/libraries/appframeworks/topicmaps/tsconfig.json
+++ b/libraries/appframeworks/topicmaps/tsconfig.json
@@ -1,14 +1,6 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
-  },
+
   "files": [],
   "include": [],
   "references": [

--- a/libraries/appframeworks/topicmaps/tsconfig.lib.json
+++ b/libraries/appframeworks/topicmaps/tsconfig.lib.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "declaration": true,
     "types": ["node", "vite/client"]
   },
   "include": ["src/**/*.ts"],

--- a/libraries/collaboration/carma-wuppertal-collab/tsconfig.json
+++ b/libraries/collaboration/carma-wuppertal-collab/tsconfig.json
@@ -1,14 +1,6 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
-  },
+
   "files": [],
   "include": [],
   "references": [

--- a/libraries/collaboration/carma-wuppertal-collab/tsconfig.lib.json
+++ b/libraries/collaboration/carma-wuppertal-collab/tsconfig.lib.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "declaration": true,
     "types": ["node", "vite/client"]
   },
   "include": ["src/**/*.ts"],

--- a/libraries/commons/debug/package.json
+++ b/libraries/commons/debug/package.json
@@ -2,6 +2,7 @@
   "name": "@carma-commons/debug",
   "version": "0.0.1",
   "main": "./index.js",
+  "type": "module",
   "types": "./index.d.ts",
   "exports": {
     ".": {

--- a/libraries/commons/document-viewer/tsconfig.json
+++ b/libraries/commons/document-viewer/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "allowJs": false,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true
   },
   "files": [],
   "include": [],

--- a/libraries/customer-specific/wuppertal/components/tsconfig.json
+++ b/libraries/customer-specific/wuppertal/components/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "allowJs": false,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
     "types": ["vite/client"]
   },
   "files": [],

--- a/libraries/mapping/carma-map-components/tsconfig.json
+++ b/libraries/mapping/carma-map-components/tsconfig.json
@@ -1,14 +1,6 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
-  },
+
   "files": [],
   "include": [],
   "references": [

--- a/libraries/mapping/carma-map-components/tsconfig.lib.json
+++ b/libraries/mapping/carma-map-components/tsconfig.lib.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "declaration": true,
     "types": ["node", "vite/client"]
   },
   "include": ["src/**/*.ts"],

--- a/libraries/mapping/carma-map-control-layout/tsconfig.json
+++ b/libraries/mapping/carma-map-control-layout/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "allowJs": false,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
+    "noImplicitAny": false,
     "types": ["vite/client"]
   },
   "files": [],

--- a/libraries/mapping/carma-map-layers/tsconfig.json
+++ b/libraries/mapping/carma-map-layers/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "allowJs": false,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true
   },
   "files": [],
   "include": [],

--- a/libraries/mapping/carma-map-utils/tsconfig.json
+++ b/libraries/mapping/carma-map-utils/tsconfig.json
@@ -1,14 +1,6 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
-  },
+
   "files": [],
   "include": [],
   "references": [

--- a/libraries/mapping/carma-map-utils/tsconfig.lib.json
+++ b/libraries/mapping/carma-map-utils/tsconfig.lib.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "declaration": true,
     "types": ["node", "vite/client"]
   },
   "include": ["src/**/*.ts"],

--- a/libraries/mapping/engines/cesium/package.json
+++ b/libraries/mapping/engines/cesium/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@carma-mapping/cesium-engine",
   "version": "0.0.1",
+  "type": "module",
   "dependencies": {},
   "main": "./index.js",
   "module": "./index.mjs",
-  "typings": "./index.d.ts"
+  "types": "./index.d.ts"
 }

--- a/libraries/mapping/engines/cesium/src/lib/CustomCesiumWidget.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/CustomCesiumWidget.tsx
@@ -20,7 +20,7 @@ import { generateRingFromDegrees } from './utils/cesiumHelpers';
 import { LatLngRadians, LatLngRecord } from '..';
 import { CUSTOM_SHADERS_DEFINITIONS } from './shaders';
 
-const unlit = new CustomShader(CUSTOM_SHADERS_DEFINITIONS.UNLIT);
+const unlit = new CustomShader(CUSTOM_SHADERS_DEFINITIONS.UNLIT!);
 
 const addDebugPrimitives = (widget: CesiumWidget, cartesian: Cartesian3) => {
   const pointCollection = new PointPrimitiveCollection();

--- a/libraries/mapping/engines/cesium/src/lib/CustomViewer/components/BaseTilesets.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/CustomViewer/components/BaseTilesets.tsx
@@ -16,10 +16,7 @@ import {
 } from 'cesium';
 import { useSecondaryStyleTilesetClickHandler } from '../../hooks';
 import { useTweakpaneCtx } from '@carma-commons/debug';
-import {
-  CUSTOM_SHADERS_DEFINITIONS,
-  CustomShaderKeys as k,
-} from '../../shaders';
+import { CUSTOM_SHADERS_DEFINITIONS, CustomShaderKeys } from '../../shaders';
 
 import { create3DTileStyle } from '../../utils';
 
@@ -27,18 +24,18 @@ const preloadWhenHidden = true;
 let enableDebugWireframe = false;
 let maximumScreenSpaceError = 8; // 16 is default but quite Low Quality
 
-const customShaderKeys = {
-  clay: k.CLAY,
-  'unlit enhanced': k.UNLIT,
-  unlit: k.UNLIT_BASE,
-  'unlit fog': k.UNLIT_FOG,
-  monochrome: k.MONOCHROME,
-  undefined: k.UNDEFINED,
+const customShaderKeys: Record<string, CustomShaderKeys> = {
+  clay: CustomShaderKeys.CLAY,
+  'unlit enhanced': CustomShaderKeys.UNLIT,
+  unlit: CustomShaderKeys.UNLIT_BASE,
+  'unlit fog': CustomShaderKeys.UNLIT_FOG,
+  monochrome: CustomShaderKeys.MONOCHROME,
+  undefined: CustomShaderKeys.UNDEFINED,
 };
 
-const DEFAULT_MESH_SHADER_KEY = k.UNLIT;
+const DEFAULT_MESH_SHADER_KEY = CustomShaderKeys.UNLIT;
 const DEFAULT_MESH_SHADER = new CustomShader(
-  CUSTOM_SHADERS_DEFINITIONS[DEFAULT_MESH_SHADER_KEY]
+  CUSTOM_SHADERS_DEFINITIONS[DEFAULT_MESH_SHADER_KEY]!
 );
 
 export const BaseTilesets = () => {
@@ -86,14 +83,9 @@ export const BaseTilesets = () => {
         setCustomShaderKey(v);
         if (tsA) {
           const def = CUSTOM_SHADERS_DEFINITIONS[customShaderKeys[v]];
-          if (def === k.UNDEFINED) {
-            setCustomMeshShader(undefined);
-            tsA.customShader = undefined;
-          } else {
-            const shader = new CustomShader(CUSTOM_SHADERS_DEFINITIONS[v]);
-            tsA.customShader = shader;
-            setCustomMeshShader(shader);
-          }
+          const shader = def ? new CustomShader(def) : undefined;
+          tsA.customShader = shader;
+          setCustomMeshShader(shader);
         }
       },
 
@@ -210,7 +202,7 @@ export const BaseTilesets = () => {
         skipLevelOfDetail={true}
         //immediatelyLoadDesiredLevelOfDetail={true}
 
-        url={tilesets.primary?.url ?? ""}
+        url={tilesets.primary?.url ?? ''}
         style={style}
         enableCollision={false}
         preloadWhenHidden={preloadWhenHidden}
@@ -227,7 +219,7 @@ export const BaseTilesets = () => {
         skipLevelOfDetail={true}
         //immediatelyLoadDesiredLevelOfDetail={true}
 
-        url={tilesets.secondary?.url ?? ""}
+        url={tilesets.secondary?.url ?? ''}
         style={style}
         //style={styleThematicLod2}
 

--- a/libraries/mapping/engines/cesium/src/lib/CustomViewer/components/ControlsUI.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/CustomViewer/components/ControlsUI.tsx
@@ -12,7 +12,16 @@ import {
   useViewerHome,
   useViewerIsMode2d,
 } from '../../CustomViewerContextProvider/slices/viewer';
-const ControlsUI = ({ showHome = true, showOrbit = true, searchComponent }) => {
+import { ReactNode } from 'react';
+const ControlsUI = ({
+  showHome = true,
+  showOrbit = true,
+  searchComponent,
+}: {
+  showHome: boolean;
+  showOrbit: boolean;
+  searchComponent: ReactNode;
+}) => {
   const home = useViewerHome();
   const isMode2d = useViewerIsMode2d();
 

--- a/libraries/mapping/engines/cesium/src/lib/CustomViewer/components/LeafletMiniMap.utils.ts
+++ b/libraries/mapping/engines/cesium/src/lib/CustomViewer/components/LeafletMiniMap.utils.ts
@@ -1,4 +1,6 @@
 /* eslint-disable */
+// @ts-nocheck
+
 
 import L, { Marker, MarkerOptions, LatLng, PointExpression } from 'leaflet';
 
@@ -50,7 +52,7 @@ export const makeLeafletMarkerRotatable = (
 
     _applyRotation: function (this: RotatableMarker) {
       if (this.options.rotationAngle) {
-        this._icon.style[L.DomUtil.TRANSFORM + 'Origin'] =
+        this._icon.style[(L.DomUtil.TRANSFORM as string) + 'Origin'] =
           this.options.rotationOrigin;
         this._icon.style[
           L.DomUtil.TRANSFORM

--- a/libraries/mapping/engines/cesium/src/lib/CustomViewer/components/TopicMap.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/CustomViewer/components/TopicMap.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from 'react';
 import { useCesium } from 'resium';
 
+// ts-expect-error import from js
 import TopicMapComponent from 'react-cismap/topicmaps/TopicMapComponent';
+// ts-expect-error import from js
 import StyledWMSTileLayer from 'react-cismap/StyledWMSTileLayer';
 
 import {

--- a/libraries/mapping/engines/cesium/src/lib/CustomViewer/components/baseTileset.hook.ts
+++ b/libraries/mapping/engines/cesium/src/lib/CustomViewer/components/baseTileset.hook.ts
@@ -7,13 +7,16 @@ import {
   setShowSecondaryTileset,
 } from '../../CustomViewerContextProvider/slices/viewer';
 import { SceneStyles } from '../../..';
-import { useCustomViewerContext } from '../../CustomViewerContextProvider/components/CustomViewerContextProvider';
+import {
+  CustomViewerContextType,
+  useCustomViewerContext,
+} from '../../CustomViewerContextProvider/components/CustomViewerContextProvider';
 
 // TODO move combined common setup out of here
 
 const setupPrimaryStyle = (
   viewer: Viewer,
-  { terrainProvider, imageryLayer }
+  { terrainProvider, imageryLayer }: CustomViewerContextType
 ) => {
   (async () => {
     viewer.scene.globe.baseColor = Color.DARKGRAY;
@@ -21,7 +24,10 @@ const setupPrimaryStyle = (
     if (viewer.scene.terrainProvider instanceof CesiumTerrainProvider) {
       //viewer.scene.terrainProvider = ellipsoidTerrainProvider;
     } else {
-      viewer.scene.terrainProvider = await terrainProvider;
+      const provider = await terrainProvider;
+      if (provider) {
+        viewer.scene.terrainProvider = provider;
+      }
     }
     // viewer.scene.globe.depthTestAgainstTerrain = false;
 
@@ -36,21 +42,24 @@ const setupPrimaryStyle = (
 
 export const setupSecondaryStyle = (
   viewer: Viewer,
-  { terrainProvider, imageryLayer }
+  { terrainProvider, imageryLayer }: CustomViewerContextType
 ) => {
   if (!viewer) return;
   (async () => {
     viewer.scene.globe.baseColor = Color.WHITE;
 
-    // console.log('setupSecondaryStyle', viewer.scene.terrainProvider);
+    // console.log('setnull) {daryStyle', viewer.scene.terrainProvider);
     if (!(viewer.scene.terrainProvider instanceof CesiumTerrainProvider)) {
-      viewer.scene.terrainProvider = await terrainProvider;
+      const provider = await terrainProvider;
+      if (provider) {
+        viewer.scene.terrainProvider = provider;
+      }
     }
     // DEPTH TEST is quite slow, only use if really necessary
     // viewer.scene.globe.depthTestAgainstTerrain = true;
     // viewer.scene.globe.show = false;
 
-    if (imageryLayer.ready) {
+    if (imageryLayer && imageryLayer.ready) {
       imageryLayer.show = true;
       // console.log('Secondary Style Setup: add imagery layer');
       if (!viewer.imageryLayers.contains(imageryLayer)) {

--- a/libraries/mapping/engines/cesium/src/lib/CustomViewer/components/controls/MapTypeSwitcher.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/CustomViewer/components/controls/MapTypeSwitcher.tsx
@@ -21,6 +21,7 @@ import {
   pickViewerCanvasCenter,
 } from '../../../utils';
 
+
 import { TopicMapContext } from 'react-cismap/contexts/TopicMapContextProvider';
 import { animateInterpolateHeadingPitchRange } from '../../../utils/cesiumAnimations';
 

--- a/libraries/mapping/engines/cesium/src/lib/CustomViewerContextProvider/components/CustomViewerContextProvider.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/CustomViewerContextProvider/components/CustomViewerContextProvider.tsx
@@ -13,7 +13,7 @@ import {
 } from 'cesium';
 import { ModelAsset, ViewerState } from '../../..';
 
-type CustomViewerContextType = {
+export type CustomViewerContextType = {
   terrainProvider: Promise<CesiumTerrainProvider> | null;
   //imageryProvider:    | WebMapServiceImageryProvider    | WebMapTileServiceImageryProvider    | null;
   imageryLayer: ImageryLayer | null;

--- a/libraries/mapping/engines/cesium/src/lib/components/ByGeojsonClassifier/hooks.ts
+++ b/libraries/mapping/engines/cesium/src/lib/components/ByGeojsonClassifier/hooks.ts
@@ -1,5 +1,6 @@
 import { pickFromClampedGeojson } from '../../utils';
 import {
+  Cartesian2,
   Color,
   ColorMaterialProperty,
   Entity,
@@ -40,7 +41,7 @@ export const useSelectAndHighlightGeoJsonEntity = (
     if (!isPrimaryStyle) {
       return;
     }
-    let originalMaterials;
+    let originalMaterials: Map<Entity, MaterialProperty>;
     if (viewer) {
       originalMaterials = new Map<Entity, MaterialProperty>();
       console.log('HOOK ByGeoJsonClassifier add ScreenSpaceEventHandler');
@@ -74,7 +75,7 @@ export const useSelectAndHighlightGeoJsonEntity = (
         }
       };
 
-      handler.current.setInputAction((event) => {
+      handler.current.setInputAction((event: { position: Cartesian2; }) => {
         let hasPick = false;
 
         // last picked object is the top one we need for highlighting

--- a/libraries/mapping/engines/cesium/src/lib/components/ByTilesetClassifier/hooks.ts
+++ b/libraries/mapping/engines/cesium/src/lib/components/ByTilesetClassifier/hooks.ts
@@ -38,7 +38,7 @@ export const useClickActionTileset = (
     }: ScreenSpaceEventHandler.PositionedEvent) => {
       if (!position) return;
       const pickedObjects = scene.drillPick(position, drillPickLimit);
-      let feature;
+      let feature: Cesium3DTileFeature | null = null;
 
       for (let i = 0; i < pickedObjects.length; i++) {
         if (
@@ -53,13 +53,13 @@ export const useClickActionTileset = (
 
       const pickedPosition = position && scene.pickPosition(position);
 
-      if (defined(feature)) {
+      if (feature !== null && defined(feature)) {
         if (feature instanceof Cesium3DTileFeature) {
-                    const propertyIds = feature.getPropertyIds();
+          const propertyIds = feature.getPropertyIds();
           const properties = propertyIds.reduce((acc, propertyId) => {
             return {
               ...acc,
-              [propertyId]: feature.getProperty(propertyId),
+              [propertyId]: feature!.getProperty(propertyId),
             };
           }, {});
 

--- a/libraries/mapping/engines/cesium/src/lib/components/MarkerContainer.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/components/MarkerContainer.tsx
@@ -16,7 +16,7 @@ import {
   Quaternion,
   Transforms,
   VerticalOrigin,
-  Math as CeMath
+  Math as CeMath,
 } from 'cesium';
 import { Marker3dData, MarkerData } from '../..';
 
@@ -109,7 +109,7 @@ export const MarkerContainer: FC<MarkerContainerProps> = ({
           ({ modelMatrix, animatedModelMatrix, model }, i) => {
             const { isCameraFacing, rotation } = model || {};
             if (model && modelMatrix && animatedModelMatrix) {
-              let scale;
+              let scale = new Cartesian3(1, 1, 1);
               if (model.fixedScale) {
                 const dist = Cartesian3.distance(
                   viewer.camera.position,

--- a/libraries/mapping/engines/cesium/src/lib/components/SearchGazetteer/SearchGazetteer.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/components/SearchGazetteer/SearchGazetteer.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useState } from 'react';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// TODO gazetteer will be replaced anyway
+import { ChangeEvent, useEffect, useState } from 'react';
 import Fuse from 'fuse.js';
 import L from 'leaflet';
 import { AutoComplete, Button } from 'antd';
 import { CloseOutlined } from '@ant-design/icons';
 import AddressLabel from './components/AddressLabel';
-import { ModelAsset, OptionItem } from './types';
+import { ModelAsset, Option, OptionItem } from './types';
 import Title from './components/Title';
 import { gazDataPrefix, sourcesConfig, stopwords } from './config';
 import { getGazData, prepareGazData, removeStopwords } from './utils';
@@ -19,7 +21,7 @@ import { Viewer } from 'cesium';
 import { removeMarker } from './tools/cesium3dMarker';
 import { removeGroundPrimitiveById } from './tools/cesium';
 
-const renderItem = (address) => {
+const renderItem = (address: any) => {
   return {
     key: address.sorter,
     value: address.string,
@@ -28,20 +30,20 @@ const renderItem = (address) => {
   };
 };
 
-const generateOptions = (results) => {
-  return results.map((result, idx) => {
+const generateOptions = (results: any[]) => {
+  return results.map((result: any) => {
     return renderItem(result.item);
   });
 };
 
-const mapDataToSearchResult = (data) => {
-  const splittedCategories = {};
+const mapDataToSearchResult = (data: any[]) => {
+  const splittedCategories: Record<string, Option[]> = {};
 
   data.forEach((item) => {
     const address = item.item;
     const catName = address.type;
 
-    if (splittedCategories.hasOwnProperty(catName)) {
+    if (Object.prototype.hasOwnProperty.call(splittedCategories, catName)) {
       splittedCategories[catName].push(renderItem(address));
     } else {
       splittedCategories[catName] = [renderItem(address)];
@@ -110,7 +112,7 @@ export function SearchGazetteer({
 
   //console.log('mapConsumers', mapConsumers);
 
-  const internalGazetteerHitTrigger = (hit) => {
+  const internalGazetteerHitTrigger = (hit: any) => {
     builtInGazetteerHitTrigger(hit, mapConsumers, {
       setGazetteerHit,
       marker3dStyle,
@@ -124,7 +126,7 @@ export function SearchGazetteer({
   const [value, setValue] = useState('');
   const [typeaheadPartValue, setTypeaheadPartValue] = useState('');
 
-  const handleSearchAutoComplete = (value) => {
+  const handleSearchAutoComplete = (value: any) => {
     if (allGazeteerData && allGazeteerData.length > 0) {
       const fuseAddressesOptions = {
         distance: 100,
@@ -135,7 +137,7 @@ export function SearchGazetteer({
       const fuse = new Fuse(allGazeteerData, fuseAddressesOptions);
       const result = fuse.search(removeStopwords(value, stopwords));
       if (!showCategories) {
-        setOptions(generateOptions(result));
+        setOptions(generateOptions(result) as any);
       } else {
         const groupedResults = mapDataToSearchResult(result);
         setSearchResult(groupedResults);
@@ -146,7 +148,7 @@ export function SearchGazetteer({
     }
   };
 
-  const handleOnSelect = (option) => {
+  const handleOnSelect = (option: any) => {
     console.log('Handle Selected Option', option);
     internalGazetteerHitTrigger([option.sData]);
     if (option.sData.type === 'bezirke' || option.sData.type === 'quartiere') {
@@ -160,7 +162,7 @@ export function SearchGazetteer({
     console.log('HOOK: gazData', gazData);
     if (!gazData) {
       console.info('no gazeteerdata defined, fetching gazData', sourcesConfig);
-      const setDataCallback = (data) => {
+      const setDataCallback = (data: any) => {
         setData(data);
         setAllGazeteerData(prepareGazData(data, stopwords));
       };
@@ -174,7 +176,7 @@ export function SearchGazetteer({
 
   useEffect(() => {}, [showCategories]);
 
-  const handleShowCategories = (e) => {
+  const handleShowCategories = (e: ChangeEvent<HTMLInputElement>) => {
     setSfStandardSearch(e.target.checked);
     setOptions([]);
     setSearchResult([]);

--- a/libraries/mapping/engines/cesium/src/lib/components/SearchGazetteer/tools/cesium3dMarker.ts
+++ b/libraries/mapping/engines/cesium/src/lib/components/SearchGazetteer/tools/cesium3dMarker.ts
@@ -75,9 +75,9 @@ const updateMarker = (viewer: Viewer) => {
 
     const { modelMatrix, animatedModelMatrix, model } = entityData;
     const { isCameraFacing, rotation } = model;
+    let scale = new Cartesian3(1, 1, 1);
 
     if (model && modelMatrix && animatedModelMatrix) {
-      let scale;
       let translation = new Cartesian3(0, 0, 0);
       if (model.fixedScale) {
         const dist = Cartesian3.distance(

--- a/libraries/mapping/engines/cesium/src/lib/components/SearchGazetteer/tools/fetching.ts
+++ b/libraries/mapping/engines/cesium/src/lib/components/SearchGazetteer/tools/fetching.ts
@@ -6,7 +6,7 @@ const noCacheInit = {
   method: 'GET',
   headers: noCacheHeaders,
 };
-export const md5FetchJSON = async (prefix, uri) => {
+export const md5FetchJSON = async (prefix: string, uri: string) => {
   console.info('uri to fetch', uri);
 
   try {
@@ -54,7 +54,7 @@ export const md5FetchJSON = async (prefix, uri) => {
     });
   }
 };
-export const cachedJSON = async (prefix, uri) => {
+export const cachedJSON = async (prefix: string, uri: string) => {
   console.log('uri to fetch from cache', uri);
 
   try {
@@ -72,7 +72,7 @@ export const cachedJSON = async (prefix, uri) => {
     });
   }
 };
-export const fetchJSON = async (uri) => {
+export const fetchJSON = async (uri: string) => {
   const data = await (await fetch(uri)).json();
   return new Promise((resolve, reject) => {
     resolve(data);
@@ -140,7 +140,12 @@ export const md5FetchText = async (prefix: string, uri: string) => {
   }
 };
 export const CACHE_JWT = '--cached--data--';
-export const md5ActionFetchDAQ = async (prefix, apiUrl, jwt, daqKey) => {
+export const md5ActionFetchDAQ = async (
+  prefix: string,
+  apiUrl: string,
+  jwt: string,
+  daqKey: string
+) => {
   const cachePrefix = '@' + prefix + '..' + apiUrl + '.' + daqKey;
   const md5Key = cachePrefix + '.md5';
   const dataKey = cachePrefix + '.data';

--- a/libraries/mapping/engines/cesium/src/lib/components/SearchGazetteer/utils.ts
+++ b/libraries/mapping/engines/cesium/src/lib/components/SearchGazetteer/utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { titleMapConfig } from './config';
 import {
   GazDataItem,
@@ -9,9 +10,9 @@ import { md5FetchText } from './tools/fetching';
 import { getGazDataFromSources } from './tools/gazetteerHelper';
 export const titleMap = new Map(Object.entries(titleMapConfig));
 
-export function removeStopwords(text, stopwords: StopWords) {
+export function removeStopwords(text: string, stopwords: StopWords) {
   const words = text.split(' ');
-  const placeholderWords = words.map((word) => {
+  const placeholderWords = words.map((word: string) => {
     // Check if the word is in the stopwords array (case insensitive)
     if (stopwords.includes(word.toLowerCase())) {
       // Replace each character in the word with an underscore
@@ -22,8 +23,8 @@ export function removeStopwords(text, stopwords: StopWords) {
   return placeholderWords.join(' ');
 }
 
-export function prepareGazData(data, stopwords: StopWords) {
-  const modifiedData = data.map((item) => {
+export function prepareGazData(data: any[], stopwords: StopWords) {
+  const modifiedData = data.map((item: any) => {
     const searchData = item?.string;
     const address = {
       ...item,

--- a/libraries/mapping/engines/cesium/src/lib/shaders.ts
+++ b/libraries/mapping/engines/cesium/src/lib/shaders.ts
@@ -9,7 +9,16 @@ export enum CustomShaderKeys {
   MONOCHROME = 'MONOCHROME',
 }
 
-export const CUSTOM_SHADERS_DEFINITIONS = {
+export type CustomShaderDefinition = {
+  lightingModel?: LightingModel;
+  fragmentShaderText?: string;
+};
+
+export const CUSTOM_SHADERS_DEFINITIONS: Record<
+  CustomShaderKeys,
+  CustomShaderDefinition | undefined
+> = {
+  [CustomShaderKeys.UNDEFINED]: undefined,
   [CustomShaderKeys.CLAY]: {
     fragmentShaderText: `
     void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)

--- a/libraries/mapping/engines/cesium/src/types/react-cismap.d.ts
+++ b/libraries/mapping/engines/cesium/src/types/react-cismap.d.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+declare module 'react-cismap/contexts/TopicMapContextProvider' {
+  import { Context } from 'react';
+  export const TopicMapContext: Context<unknown>;
+  export default TopicMapContext;
+}
+
+declare module 'react-cismap/topicmaps/TopicMapComponent' {
+  const TopicMapComponent: any;
+  export default TopicMapComponent;
+}
+
+declare module 'react-cismap/StyledWMSTileLayer' {
+  const StyledWMSTileLayer: any;
+  export default StyledWMSTileLayer;
+}
+
+declare module 'react-cismap/*' {
+  const content: any;
+  export default content;
+}

--- a/libraries/mapping/engines/cesium/tsconfig.json
+++ b/libraries/mapping/engines/cesium/tsconfig.json
@@ -1,17 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
-    "allowJs": false,
-    "allowSyntheticDefaultImports": true,
-    "declaration": true,
-    "declarationMap": true,
-    "esModuleInterop": false,
-    "forceConsistentCasingInFileNames": true,
-    "jsx": "react-jsxdev",
-    "strict": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noFallthroughCasesInSwitch": true
+    "noImplicitAny": false
   },
   "files": [],
   "include": [],

--- a/libraries/mapping/engines/leaflet/tsconfig.json
+++ b/libraries/mapping/engines/leaflet/tsconfig.json
@@ -1,14 +1,6 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
-  },
+
   "files": [],
   "include": [],
   "references": [

--- a/libraries/mapping/engines/leaflet/tsconfig.lib.json
+++ b/libraries/mapping/engines/leaflet/tsconfig.lib.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
-    "declaration": true,
     "types": ["node", "vite/client"]
   },
   "include": ["src/**/*.ts"],

--- a/libraries/mapping/engines/maplibre/tsconfig.json
+++ b/libraries/mapping/engines/maplibre/tsconfig.json
@@ -1,14 +1,6 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
-  },
+
   "files": [],
   "include": [],
   "references": [

--- a/libraries/mapping/engines/maplibre/tsconfig.lib.json
+++ b/libraries/mapping/engines/maplibre/tsconfig.lib.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
-    "declaration": true,
     "types": ["node", "vite/client"]
   },
   "include": ["src/**/*.ts"],

--- a/playgrounds/cesium/tsconfig.json
+++ b/playgrounds/cesium/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "compilerOptions": {
-    "allowJs": false,
-    "allowSyntheticDefaultImports": true,
-    "declaration": true,
-    "declarationMap": true,
-    "esModuleInterop": false,
-    "forceConsistentCasingInFileNames": true,
-    "jsx": "react-jsx",
-    "strict": true,
+    "noImplicitAny": false,
+
     "types": ["vite/client", "vitest"]
   },
   "files": [],

--- a/playgrounds/cesium/tsconfig.prod.json
+++ b/playgrounds/cesium/tsconfig.prod.json
@@ -2,8 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "sourceMap": true,
     "removeComments": true,
-    "forceConsistentCasingInFileNames": true
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,22 +1,30 @@
 {
   "compileOnSave": false,
+  "exclude": ["node_modules", "tmp"],
   "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
+
+    "jsx": "react-jsxdev",
+    "lib": ["es2020", "dom"],
+
+    "baseUrl": ".",
     "rootDir": ".",
+
+    "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
-    "declaration": false,
-    "moduleResolution": "node",
+
+    "strict": true,
+
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "noImplicitAny": false,
     "importHelpers": true,
-    "target": "es2015",
-    "module": "esnext",
-    "lib": ["es2020", "dom"],
-    "skipLibCheck": true,
     "skipDefaultLibCheck": true,
-    "baseUrl": ".",
-    "jsx": "react",
+    "skipLibCheck": true,
+
     "paths": {
       "@carma-apps/envirometrics": [
         "libraries/appframeworks/envirometrics/src/index.ts"
@@ -69,6 +77,5 @@
         "libraries/collaboration/carma-wuppertal-collab/src/commons/index.ts"
       ]
     }
-  },
-  "exclude": ["node_modules", "tmp"]
+  }
 }


### PR DESCRIPTION
WIP do not merge, need more testing on all projects.

Goal is to remove all duplication and unneeded overrides in tsconfig referencing tsconfig.base

https://github.com/cismet/carma/blob/fc1a56dc6d567c5312d1d1ba18050bb4dd856845/tsconfig.base.json

// eventually structure by 
org from
https://www.typescriptlang.org/tsconfig/


    "target": "es2020",
    "module": "esnext",
    "moduleResolution": "bundler",
    "esModuleInterop": true,

    "jsx": "react-jsxdev",
    "lib": ["es2020", "dom"],

    "baseUrl": ".",
    "rootDir": ".",

    "declaration": true,
    "declarationMap": true,
    "sourceMap": true,

    **"strict": true,** 

    "emitDecoratorMetadata": true,
    "experimentalDecorators": true,
    "importHelpers": true,
    "skipDefaultLibCheck": true,
    "skipLibCheck": true,
    
    
    then in existing modules override the strict settings until it works with
most importantly    
        "noImplicitAny": false,
        
        
        new projects apps and libs should follow the default base rules
