### PR TITLE
3814/3d compass and animation handling for zoom buttons

### DIFF
--- a/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
+++ b/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
@@ -4,6 +4,7 @@ import { useLocation, useSearchParams } from "react-router-dom";
 import L from "leaflet";
 import { isMobile } from "react-device-detect";
 import proj4 from "proj4";
+import { Math as CesiumMath } from "cesium";
 
 import { Tooltip } from "antd";
 
@@ -68,6 +69,7 @@ import {
   useHomeControl,
   useZoomControls as useZoomControlsCesium,
   setCurrentSceneStyle,
+  PitchingCompass,
 } from "@carma-mapping/cesium-engine";
 import { LibFuzzySearch, SearchResultItem } from "@carma-mapping/fuzzy-search";
 import { SelectionItem } from "libraries/appframeworks/portals/src/lib/components/SelectionProvider.tsx";
@@ -165,13 +167,17 @@ export const GeoportalMap = () => {
   const showMeasurementButton = useSelector(getShowMeasurementButton);
   const focusMode = useSelector(getFocusMode);
   const selectedFeature = useSelector(getSelectedFeature);
-  const { viewerRef, terrainProviderRef, surfaceProviderRef } =
-    useCesiumContext();
+  const {
+    viewerRef,
+    viewerAnimationMapRef,
+    terrainProviderRef,
+    surfaceProviderRef,
+  } = useCesiumContext();
   const homeControl = useHomeControl();
   const {
     handleZoomIn: handleZoomInCesium,
     handleZoomOut: handleZoomOutCesium,
-  } = useZoomControlsCesium(viewerRef);
+  } = useZoomControlsCesium(viewerRef, viewerAnimationMapRef);
   const { getLeafletZoom, zoomInLeaflet, zoomOutLeaflet } =
     useLeafletZoomControls();
   const showPrimaryTileset = useSelector(selectShowPrimaryTileset);
@@ -561,12 +567,21 @@ export const GeoportalMap = () => {
             }}
             ref={tourRefLabels.toggle2d3d}
           />
-
+          <Tooltip title="Nach Norden ausrichten" placement="right">
+            <ControlButtonStyler
+              disabled={isMode2d}
+              ref={tourRefLabels.alignNorth}
+              dataTestId="compass-control"
+            >
+              <PitchingCompass
+                viewerRef={viewerRef}
+                viewerAnimationMapRef={viewerAnimationMapRef}
+                maxPitch={CesiumMath.toRadians(-30)}
+              />
+            </ControlButtonStyler>
+          </Tooltip>
           {
-            //<SceneStyleToggle />
-            <Compass ref={tourRefLabels.alignNorth} disabled={isMode2d} />
             // TODO implement cesium home action with generic home control for all mapping engines
-            //<HomeControl />
           }
         </Control>
       )}

--- a/envirometrics/wuppertal/floodingmap/src/App.tsx
+++ b/envirometrics/wuppertal/floodingmap/src/App.tsx
@@ -1,6 +1,8 @@
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import { Tooltip } from "antd";
+import { Math as CesiumMath } from "cesium";
+
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faCompress,
@@ -31,10 +33,10 @@ import { getApplicationVersion } from "@carma-commons/utils";
 import { getCollabedHelpComponentConfig } from "@carma-collab/wuppertal/hochwassergefahrenkarte";
 
 import {
-  Compass,
   CustomViewer,
   getDegreesFromCartesian,
   MapTypeSwitcher,
+  PitchingCompass,
   selectViewerHome,
   selectViewerIsMode2d,
   selectViewerModels,
@@ -76,13 +78,17 @@ function App({ sync = false }: { sync?: boolean }) {
   const [hochwasserschutz, setHochwasserschutz] = useState(true);
 
   // CONTROLS
-  const { viewerRef, terrainProviderRef, surfaceProviderRef } =
-    useCesiumContext();
+  const {
+    viewerRef,
+    viewerAnimationMapRef,
+    terrainProviderRef,
+    surfaceProviderRef,
+  } = useCesiumContext();
   const homeControl = useHomeControl();
   const {
     handleZoomIn: handleZoomInCesium,
     handleZoomOut: handleZoomOutCesium,
-  } = useZoomControls(viewerRef);
+  } = useZoomControls(viewerRef, viewerAnimationMapRef);
   const { zoomInLeaflet, zoomOutLeaflet } = useLeafletZoomControls();
 
   // LEAFLET related
@@ -256,7 +262,19 @@ function App({ sync = false }: { sync?: boolean }) {
             <MapTypeSwitcher
               duration={CESIUM_CONFIG.transitions.mapMode.duration}
             />
-            <Compass disabled={isMode2d} />
+            <Tooltip title="Nach Norden ausrichten" placement="right">
+              <ControlButtonStyler
+                disabled={isMode2d}
+                //ref={tourRefLabels.alignNorth}
+                dataTestId="compass-control"
+              >
+                <PitchingCompass
+                  viewerRef={viewerRef}
+                  viewerAnimationMapRef={viewerAnimationMapRef}
+                  maxPitch={CesiumMath.toRadians(-30)}
+                />
+              </ControlButtonStyler>
+            </Tooltip>
           </Control>
           <Control position="bottomleft" order={10}>
             <div data-test-id="fuzzy-search" className="h-full w-full">

--- a/libraries/mapping/engines/cesium/src/index.ts
+++ b/libraries/mapping/engines/cesium/src/index.ts
@@ -50,7 +50,10 @@ export {
   removeGroundPrimitiveById,
 } from "./lib/utils/cesiumGroundPrimitives";
 export { addCesiumMarker, removeCesiumMarker } from "./lib/utils/cesiumMarkers";
-export { setupCesiumEnvironment } from "./lib/utils/cesiumSetup";
+export {
+  getIsViewerReadyAsync,
+  setupCesiumEnvironment,
+} from "./lib/utils/cesiumSetup";
 export {
   distanceFromZoomLevel,
   getHeadingPitchRangeFromZoom,

--- a/libraries/mapping/engines/cesium/src/index.ts
+++ b/libraries/mapping/engines/cesium/src/index.ts
@@ -34,6 +34,8 @@ export {
   type ForwardedCesiumError,
 } from "./lib/utils/CesiumErrorToErrorBoundaryForwarder";
 
+export { applyRollToHeadingForCameraNearNadir } from "./lib/utils/cesiumCamera";
+
 export {
   pickViewerCanvasCenter,
   getDegreesFromCartesian,

--- a/libraries/mapping/engines/cesium/src/lib/CesiumContext.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/CesiumContext.tsx
@@ -7,9 +7,11 @@ import {
   Viewer,
   Cesium3DTileset,
 } from "cesium";
+import { ViewerAnimationMap } from "./utils/viewerAnimationMap";
 
 export interface CesiumContextType {
   viewerRef: MutableRefObject<Viewer | null>;
+  viewerAnimationMapRef: MutableRefObject<ViewerAnimationMap | null>;
   terrainProviderRef: MutableRefObject<CesiumTerrainProvider | null>;
   surfaceProviderRef: MutableRefObject<CesiumTerrainProvider | null>;
   imageryLayerRef: MutableRefObject<ImageryLayer | null>;

--- a/libraries/mapping/engines/cesium/src/lib/CesiumContextProvider.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/CesiumContextProvider.tsx
@@ -16,6 +16,10 @@ import {
   ProviderConfig,
 } from "./utils/cesiumProviders";
 import { loadTileset, TilesetConfigs } from "./utils/cesiumTilesetProviders";
+import {
+  initViewerAnimationMap,
+  ViewerAnimationMap,
+} from "./utils/viewerAnimationMap";
 
 export const CesiumContextProvider = ({
   children,
@@ -28,6 +32,9 @@ export const CesiumContextProvider = ({
 }) => {
   // Use refs for Cesium instances to prevent re-renders
   const viewerRef = useRef<Viewer | null>(null);
+  const viewerAnimationMapRef = useRef<ViewerAnimationMap | null>(
+    initViewerAnimationMap()
+  );
   const ellipsoidTerrainProviderRef = useRef(new EllipsoidTerrainProvider());
   const terrainProviderRef = useRef<CesiumTerrainProvider | null>(null);
   const surfaceProviderRef = useRef<CesiumTerrainProvider | null>(null);
@@ -148,6 +155,7 @@ export const CesiumContextProvider = ({
   const contextValue = useMemo<CesiumContextType>(
     () => ({
       viewerRef,
+      viewerAnimationMapRef,
       ellipsoidTerrainProviderRef,
       terrainProviderRef,
       surfaceProviderRef,

--- a/libraries/mapping/engines/cesium/src/lib/CustomViewerPlayground.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/CustomViewerPlayground.tsx
@@ -1,11 +1,4 @@
-import {
-  ReactNode,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { ReactNode, useContext, useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
 
@@ -25,8 +18,6 @@ import { useTweakpaneCtx } from "@carma-commons/debug";
 
 import {
   selectShowSecondaryTileset,
-  selectViewerHome,
-  selectViewerHomeOffset,
   selectViewerIsMode2d,
 } from "./slices/cesium";
 
@@ -84,7 +75,7 @@ type CustomViewerProps = {
 };
 
 export function CustomViewerPlayground(props: CustomViewerProps) {
-  const { viewerRef } = useCesiumContext();
+  const { viewerRef, viewerAnimationMapRef } = useCesiumContext();
   let viewer = useCesiumViewer();
 
   const isSecondaryStyle = useSelector(selectShowSecondaryTileset);
@@ -428,6 +419,8 @@ export function CustomViewerPlayground(props: CustomViewerProps) {
       {showControls && (
         <ControlsUI
           viewerRef={viewerRef}
+          viewerAnimationMapRef={viewerAnimationMapRef}
+          isViewerReady={true} // TODO: check if ready properly
           showHome={showHome}
           showOrbit={showOrbit}
         />

--- a/libraries/mapping/engines/cesium/src/lib/components/ControlsUI.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/components/ControlsUI.tsx
@@ -7,20 +7,25 @@ import { Compass } from "./controls/Compass";
 import ControlContainer from "./controls/ControlContainer";
 import ControlGroup from "./controls/ControlGroup";
 import { HomeControl } from "./controls/HomeControl";
-import MapTypeSwitcher from "./controls/MapTypeSwitcher";
+import { MapTypeSwitcher } from "./controls/MapTypeSwitcher";
 import LockCenterControl from "./controls/LockCenterControl";
 import OrbitControl from "./controls/OrbitControl";
 import { SceneStyleToggle } from "./controls/SceneStyleToggle";
 import ZoomControls from "./controls/ZoomControls";
+import { ViewerAnimationMap } from "../utils/viewerAnimationMap";
 
 const ControlsUI = ({
   showHome = true,
   showOrbit = true,
   viewerRef,
+  viewerAnimationMapRef,
+  isViewerReady,
 }: {
   showHome?: boolean;
   showOrbit?: boolean;
   viewerRef: React.RefObject<Viewer | null>;
+  viewerAnimationMapRef: React.RefObject<ViewerAnimationMap | null>;
+  isViewerReady: boolean;
 }) => {
   const home = useSelector(selectViewerHome);
 
@@ -37,7 +42,10 @@ const ControlsUI = ({
             visibility: isMode2d ? "hidden" : "visible",
           }}
         >
-          <ZoomControls viewerRef={viewerRef} />
+          <ZoomControls
+            viewerRef={viewerRef}
+            viewerAnimationMapRef={viewerAnimationMapRef}
+          />
           {showHome && home && (
             <ControlGroup>
               <HomeControl />

--- a/libraries/mapping/engines/cesium/src/lib/components/controls/PitchingCompass/CompassNeedleSVG.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/components/controls/PitchingCompass/CompassNeedleSVG.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
+import { Math as CesiumMath } from "cesium";
 
-const PI_OVER_2 = Math.PI / 2;
+const PITCH_HORIZON_OFFSET = CesiumMath.PI_OVER_TWO - 0.2; // avoid showing completely flat from the side
 
 export const CompassNeedleSVG = ({
   pitch = 0,
@@ -18,7 +19,11 @@ export const CompassNeedleSVG = ({
   useEffect(() => {
     if (pitch && heading) {
       const normalizedHeading = -heading;
-      const normalizedPitch = pitch + PI_OVER_2;
+      const normalizedPitch = CesiumMath.clamp(
+        pitch + CesiumMath.PI_OVER_TWO, // rotate pitch range into screen plane
+        0, // NADIR end of range
+        PITCH_HORIZON_OFFSET // Horizon end of range
+      );
       const transform = `rotateX(${normalizedPitch}rad) rotateZ(${normalizedHeading}rad)`;
       setTransform(transform);
     }

--- a/libraries/mapping/engines/cesium/src/lib/components/controls/PitchingCompass/CompassNeedleSVG.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/components/controls/PitchingCompass/CompassNeedleSVG.tsx
@@ -6,8 +6,8 @@ const PITCH_HORIZON_OFFSET = CesiumMath.PI_OVER_TWO - 0.2; // avoid showing comp
 export const CompassNeedleSVG = ({
   pitch = 0,
   heading = 0,
-  northColor = "#d65",
-  neutralColor = "#bbb",
+  northColor = "#333",
+  neutralColor = "#ccc",
 }: {
   pitch?: number;
   heading?: number;
@@ -24,17 +24,26 @@ export const CompassNeedleSVG = ({
         0, // NADIR end of range
         PITCH_HORIZON_OFFSET // Horizon end of range
       );
-      const transform = `rotateX(${normalizedPitch}rad) rotateZ(${normalizedHeading}rad)`;
+      // scale the needle for lower pitches for improved visibility
+      // linear scaling makes the tilting effect look less consistent
+      const transform = `scale(${Math.pow(
+        1 + normalizedPitch * 0.1,
+        3
+      )}) rotateX(${normalizedPitch}rad) rotateZ(${normalizedHeading}rad)`;
       setTransform(transform);
     }
   }, [pitch, heading]);
 
+  // style adjusted from maplibre-gl-ctrl-compass
+  // https://github.com/maplibre/maplibre-gl-js/blob/a99fe93fe8ac1505b1b450cd3c1d9b2b8394bd8c/src/css/svg/maplibregl-ctrl-compass.svg#L3
+
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="10"
-      height="10"
-      viewBox="-5 -5 10 10"
+      width="29"
+      height="29"
+      viewBox="0 0 29 29"
+      fill={northColor}
       style={{
         width: "100%",
         height: "100%",
@@ -43,9 +52,8 @@ export const CompassNeedleSVG = ({
         transformStyle: "preserve-3d",
       }}
     >
-      <path d="M0,-5 L2,0 L-2,0 Z" fill={northColor} />
-      <path d="M0,5 L-2 ,0 L2,0 Z" fill={neutralColor} />
-      <circle cx="0" cy="0" r="0.7" fill="#333" />
+      <path d="m10.5 14 4-8 4 8z" />
+      <path d="m10.5 16 4 8 4-8z" fill={neutralColor} />
     </svg>
   );
 };

--- a/libraries/mapping/engines/cesium/src/lib/components/controls/PitchingCompass/PitchingCompass.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/components/controls/PitchingCompass/PitchingCompass.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../../utils/cesiumAnimateOrbits";
 
 import { CompassNeedleSVG } from "./CompassNeedleSVG";
+import { applyRollToHeadingForCameraNearNadir } from "../../../utils/cesiumCamera";
 
 interface RotateButtonProps {
   viewerRef: React.RefObject<Viewer | null>;
@@ -205,11 +206,13 @@ export const PitchingCompass: React.FC<RotateButtonProps> = ({
   };
 
   useEffect(() => {
-    if (viewerRef.current) {
-      const camera = viewerRef.current.scene.camera;
+    const viewer = viewerRef.current;
+    if (viewer) {
+      const camera = viewer.scene.camera;
       const updateOrientation = () => {
         setCurrentPitch(camera.pitch);
-        setCurrentHeading(camera.heading);
+        // correct heading for compass needle
+        setCurrentHeading(applyRollToHeadingForCameraNearNadir(camera));
       };
       camera.percentageChanged = 0.01;
       camera.changed.addEventListener(updateOrientation);

--- a/libraries/mapping/engines/cesium/src/lib/components/controls/PitchingCompass/PitchingCompass.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/components/controls/PitchingCompass/PitchingCompass.tsx
@@ -96,11 +96,6 @@ export const PitchingCompass: React.FC<RotateButtonProps> = ({
   };
 
   useEffect(() => {
-    console.log(
-      "useEffect RotateButton",
-      viewerRef.current,
-      viewerAnimationMapRef.current
-    );
     if (!viewerRef.current || !viewerAnimationMapRef.current) return;
     const viewer = viewerRef.current;
     const animationMap = viewerAnimationMapRef.current;
@@ -175,16 +170,33 @@ export const PitchingCompass: React.FC<RotateButtonProps> = ({
     ) {
       const orbitPoint = getOrbitPoint(viewerRef.current);
       if (orbitPoint) {
-        const isDoubleClick = event.detail >= 2;
-        const targetPitch = CesiumMath.toRadians(
-          isDoubleClick ? PITCH.ORTHO : pitchOblique
-        );
         animateCamera(
           viewerRef.current,
           viewerAnimationMapRef.current,
           orbitPoint,
           0,
-          targetPitch,
+          pitchOblique,
+          initialRange,
+          durationReset
+        );
+      }
+    }
+  };
+
+  const handleDoubleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (
+      viewerRef.current &&
+      viewerAnimationMapRef.current &&
+      initialRange !== null
+    ) {
+      const orbitPoint = getOrbitPoint(viewerRef.current);
+      if (orbitPoint) {
+        animateCamera(
+          viewerRef.current,
+          viewerAnimationMapRef.current,
+          orbitPoint,
+          0,
+          PITCH.ORTHO,
           initialRange,
           durationReset
         );
@@ -215,6 +227,7 @@ export const PitchingCompass: React.FC<RotateButtonProps> = ({
       onMouseDown={handleMouseDown}
       onMouseUp={handleControlMouseUp}
       onClick={handleButtonClick}
+      onDoubleClick={handleDoubleClick}
       style={{
         border: "none",
         background: "transparent",

--- a/libraries/mapping/engines/cesium/src/lib/components/controls/PitchingCompass/Readme.md
+++ b/libraries/mapping/engines/cesium/src/lib/components/controls/PitchingCompass/Readme.md
@@ -1,0 +1,3 @@
+## Attributions
+
+- Compass style adapted from [MapLibre GL JS](https://github.com/maplibre/maplibre-gl-js/blob/a99fe93fe8ac1505b1b450cd3c1d9b2b8394bd8c/src/css/svg/maplibregl-ctrl-compass.svg).

--- a/libraries/mapping/engines/cesium/src/lib/components/controls/ZoomControls.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/components/controls/ZoomControls.tsx
@@ -3,16 +3,21 @@ import { ReactNode } from "react";
 import { Viewer } from "cesium";
 
 import { useZoomControls } from "../../hooks/useZoomControls";
+import { ViewerAnimationMap } from "../../utils/viewerAnimationMap";
 
 type ZoomControlsProps = {
   children?: ReactNode;
   role?: string;
   ariaLabel?: string;
   viewerRef: React.RefObject<Viewer | null>;
+  viewerAnimationMapRef: React.RefObject<ViewerAnimationMap | null>;
 };
 
 const ZoomControls = (props: ZoomControlsProps) => {
-  const { handleZoomIn, handleZoomOut } = useZoomControls(props.viewerRef);
+  const { handleZoomIn, handleZoomOut } = useZoomControls(
+    props.viewerRef,
+    props.viewerAnimationMapRef
+  );
 
   return (
     <div className="leaflet-control-zoom leaflet-bar leaflet-control">

--- a/libraries/mapping/engines/cesium/src/lib/hooks/useCameraPitchSoftLimiter.ts
+++ b/libraries/mapping/engines/cesium/src/lib/hooks/useCameraPitchSoftLimiter.ts
@@ -16,8 +16,10 @@ const useCameraPitchSoftLimiter = (
     minPitchDeg?: number;
     resetPitchOffsetDeg?: number;
     pitchLimiter?: boolean;
+    debug?: boolean;
   } = {}
 ) => {
+  const debug = options.debug ?? false;
   const pitchLimiter =
     options.pitchLimiter === undefined ? true : options.pitchLimiter;
   const minPitchDeg = options.minPitchDeg || 22;
@@ -37,9 +39,10 @@ const useCameraPitchSoftLimiter = (
 
   useEffect(() => {
     if (viewer && !isMode2d && collisions && pitchLimiter) {
-      console.debug(
-        "HOOK [2D3D|CESIUM] viewer changed add new Cesium MoveEnd Listener to correct camera pitch"
-      );
+      debug &&
+        console.debug(
+          "HOOK [2D3D|CESIUM] viewer changed add new Cesium MoveEnd Listener to correct camera pitch"
+        );
 
       const resetPitchRad = CesiumMath.toRadians(
         -(minPitchDeg + resetPitchOffsetDeg)
@@ -47,19 +50,21 @@ const useCameraPitchSoftLimiter = (
       const minPitchRad = CesiumMath.toRadians(-minPitchDeg);
 
       const moveEndListener = async () => {
-        console.debug(
-          "HOOK [2D3D|CESIUM] Soft Pitch Limiter",
-          viewer.camera.pitch,
-          minPitchRad,
-          resetPitchRad
-        );
-        const isPitchTooLow = collisions && viewer.camera.pitch > minPitchRad;
-        if (isPitchTooLow) {
+        debug &&
           console.debug(
-            "LISTENER HOOK [2D3D|CESIUM|CAMERA]: reset pitch soft",
+            "HOOK [2D3D|CESIUM] Soft Pitch Limiter",
             viewer.camera.pitch,
+            minPitchRad,
             resetPitchRad
           );
+        const isPitchTooLow = collisions && viewer.camera.pitch > minPitchRad;
+        if (isPitchTooLow) {
+          debug &&
+            console.debug(
+              "LISTENER HOOK [2D3D|CESIUM|CAMERA]: reset pitch soft",
+              viewer.camera.pitch,
+              resetPitchRad
+            );
           // TODO Get CenterPos Lower from screen if distance is muliple of elevation. prevent pitch around distant point on horizon
           const centerPos = pickViewerCanvasCenter(viewer).scenePosition;
           if (centerPos) {
@@ -97,6 +102,7 @@ const useCameraPitchSoftLimiter = (
     dispatch,
     minPitchDeg,
     resetPitchOffsetDeg,
+    debug,
   ]);
 };
 

--- a/libraries/mapping/engines/cesium/src/lib/hooks/useCameraRollSoftLimiter.ts
+++ b/libraries/mapping/engines/cesium/src/lib/hooks/useCameraRollSoftLimiter.ts
@@ -9,9 +9,17 @@ import {
 } from "../slices/cesium";
 import { useCesiumViewer } from "./useCesiumViewer";
 
+const NADIR_THRESHOLD = 0.2;
+
 const useCameraRollSoftLimiter = ({
   pitchLimiter = true,
-}: { pitchLimiter?: boolean } = {}) => {
+  debug = false,
+  nadirThreshold = NADIR_THRESHOLD,
+}: {
+  pitchLimiter?: boolean;
+  debug?: boolean;
+  nadirThreshold?: number;
+} = {}) => {
   const viewer = useCesiumViewer();
   const dispatch = useDispatch();
   const isMode2d = useSelector(selectViewerIsMode2d);
@@ -23,20 +31,33 @@ const useCameraRollSoftLimiter = ({
 
   useEffect(() => {
     if (viewer && pitchLimiter) {
-      console.debug(
-        "HOOK [2D3D|CESIUM] viewer changed add new Cesium MoveEnd Listener to reset rolled camera"
-      );
+      debug &&
+        console.debug(
+          "HOOK [2D3D|CESIUM] viewer changed add new Cesium MoveEnd Listener to reset rolled camera"
+        );
       const moveEndListener = async () => {
         if (viewer.camera.position && !isMode2d) {
           const rollDeviation =
             Math.abs(CesiumMath.TWO_PI - viewer.camera.roll) %
             CesiumMath.TWO_PI;
 
-          if (rollDeviation > 0.02) {
+          const isCloseToNadir =
+            Math.abs(viewer.camera.pitch + Math.PI / 2) < nadirThreshold;
+
+          debug &&
             console.debug(
-              "LISTENER HOOK [2D3D|CESIUM|CAMERA]: flyTo reset roll 2D3D",
-              rollDeviation
+              "LISTENER HOOK [2D3D|CESIUM|CAMERA]: nadir",
+              isCloseToNadir,
+              viewer.camera.pitch,
+              Math.abs(viewer.camera.pitch + Math.PI / 2)
             );
+
+          if (rollDeviation > 0.02 && !isCloseToNadir) {
+            debug &&
+              console.debug(
+                "LISTENER HOOK [2D3D|CESIUM|CAMERA]: flyTo reset roll 2D3D",
+                rollDeviation
+              );
             const duration = Math.min(rollDeviation, 1);
             dispatch(setIsAnimating());
             viewer.camera.flyTo({
@@ -57,7 +78,15 @@ const useCameraRollSoftLimiter = ({
         viewer.camera.moveEnd.removeEventListener(moveEndListener);
       };
     }
-  }, [viewer, isMode2d, pitchLimiter, onComplete, dispatch]);
+  }, [
+    viewer,
+    isMode2d,
+    pitchLimiter,
+    onComplete,
+    dispatch,
+    debug,
+    nadirThreshold,
+  ]);
 };
 
 export default useCameraRollSoftLimiter;

--- a/libraries/mapping/engines/cesium/src/lib/hooks/useZoomControls.ts
+++ b/libraries/mapping/engines/cesium/src/lib/hooks/useZoomControls.ts
@@ -1,52 +1,121 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
-import { Viewer } from "cesium";
+import { Viewer, Cartesian2, Cartesian3, EasingFunction, Ray } from "cesium";
+import {
+  cancelViewerAnimation,
+  type ViewerAnimationMap,
+} from "../utils/viewerAnimationMap";
 
-const MOVERATE_FACTOR = 0.33;
+type ZoomOptions = {
+  duration: number;
+  minDistance: number;
+  moveRateFactor: number;
+};
+
+const defaultZoomOptions: ZoomOptions = {
+  duration: 0.5,
+  minDistance: 100,
+  moveRateFactor: 1,
+};
+
+const zoom = (
+  viewer: Viewer,
+  viewerAnimationMap: ViewerAnimationMap,
+  isZoomOut = false,
+  { duration, minDistance, moveRateFactor }: ZoomOptions
+) => {
+  const scene = viewer.scene;
+  const camera = viewer.camera;
+  let wasCancelled = false;
+
+  if (viewerAnimationMap.get(viewer)) {
+    cancelViewerAnimation(viewer, viewerAnimationMap);
+    wasCancelled = true;
+  }
+
+  // undocumented Cesium feature
+  // TODO: replace with a public API when one is available to check for ongoing flyTo animations
+
+  const isAnimating =
+    (viewer.scene as unknown as { tweens: [] }).tweens.length > 0;
+
+  if (isAnimating) {
+    camera.completeFlight();
+    console.debug("completing previous zoom or other flyTo animation");
+    wasCancelled = true;
+  }
+
+  const screenCenter = new Cartesian2(
+    scene.canvas.clientWidth / 2,
+    scene.canvas.clientHeight / 2
+  );
+  const pickRay = camera.getPickRay(screenCenter);
+
+  const pickPosition = pickRay && scene.globe.pick(pickRay, scene);
+  if (!pickPosition) return;
+
+  const cameraPosition = camera.position;
+  const distance = Cartesian3.distance(cameraPosition, pickPosition);
+
+  let offsetOnRay = isZoomOut
+    ? -distance * moveRateFactor
+    : (distance * 0.5) / moveRateFactor;
+
+  // clamp to minDistance
+  if (distance - offsetOnRay < minDistance) {
+    offsetOnRay = distance - minDistance;
+  }
+
+  // Move the camera along the ray
+  const newPosition = Ray.getPoint(pickRay, offsetOnRay, new Cartesian3());
+  camera.flyTo({
+    destination: newPosition,
+    orientation: {
+      heading: camera.heading,
+      pitch: camera.pitch,
+      roll: camera.roll,
+    },
+    duration: duration,
+    easingFunction: wasCancelled
+      ? EasingFunction.QUADRATIC_OUT
+      : EasingFunction.QUADRATIC_IN_OUT,
+  });
+  return;
+};
 
 /**
  * @param viewerRef - reference to the Cesium Viewer component
- * @param moveRateFactor - The factor by which the camera's default zoom/moveRate increment be amplified by.
+ * @param moveRateFactor - The factor by which the camera's default zoom/moveRate increment be amplified by, default 1.
  */
 
 export function useZoomControls(
   viewerRef: React.MutableRefObject<Viewer | null>,
-  moveRateFactor = MOVERATE_FACTOR
+  viewerAnimationMapRef: React.MutableRefObject<ViewerAnimationMap | null>,
+  zoomOptions: Partial<ZoomOptions> = {}
 ) {
   const viewer = viewerRef.current;
+  const viewerAnimationMap = viewerAnimationMapRef.current;
+  const opts = useMemo(
+    () => ({ ...defaultZoomOptions, ...zoomOptions }),
+    [zoomOptions]
+  );
 
   const handleZoomIn = useCallback(
     (event: React.MouseEvent) => {
+      if (!viewer || !viewerAnimationMap) return;
       event.preventDefault();
-      if (!viewer) return;
-      const scene = viewer.scene;
-      const camera = viewer.camera;
-      const ellipsoid = scene.globe.ellipsoid;
-
-      const cameraHeight = ellipsoid.cartesianToCartographic(
-        camera.position
-      ).height;
-      const moveRate = cameraHeight * moveRateFactor;
-      camera.moveForward(moveRate);
+      zoom(viewer, viewerAnimationMap, false, opts);
     },
-    [viewer, moveRateFactor]
+    [viewer, viewerAnimationMap, opts]
   );
 
   const handleZoomOut = useCallback(
     (event: React.MouseEvent) => {
+      if (!viewer || !viewerAnimationMap) return;
       event.preventDefault();
-      if (!viewer) return;
-      const scene = viewer.scene;
-      const camera = viewer.camera;
-      const ellipsoid = scene.globe.ellipsoid;
-
-      const cameraHeight = ellipsoid.cartesianToCartographic(
-        camera.position
-      ).height;
-      const moveRate = cameraHeight * moveRateFactor;
-      camera.moveBackward(moveRate);
+      zoom(viewer, viewerAnimationMap, true, opts);
     },
-    [viewer, moveRateFactor]
+    [viewer, viewerAnimationMap, opts]
   );
 
   return { handleZoomIn, handleZoomOut };

--- a/libraries/mapping/engines/cesium/src/lib/utils/cesiumAnimateOrbits.ts
+++ b/libraries/mapping/engines/cesium/src/lib/utils/cesiumAnimateOrbits.ts
@@ -13,8 +13,8 @@ import { AnimationType, ViewerAnimationMap } from "./viewerAnimationMap";
 
 export enum PITCH {
   HORIZONTAL = 0,
-  OBLIQUE = -45,
-  ORTHO = -90,
+  OBLIQUE = CesiumMath.toRadians(-45),
+  ORTHO = CesiumMath.toRadians(-90),
 }
 
 /**
@@ -80,12 +80,7 @@ function runAnimation(
       viewerAnimationMap.delete(viewer); // Clear the animation entry
     }
   };
-  const animationFrameId = requestAnimationFrame(animate);
-  viewerAnimationMap.set(viewer, {
-    id: animationFrameId,
-    type: animationType,
-    cancelable: true,
-  });
+  animate(performance.now());
 }
 
 /**
@@ -112,8 +107,9 @@ export const animateCamera = (
   const previousAnimation = viewerAnimationMap.get(viewer);
   if (previousAnimation) {
     if (previousAnimation.cancelable) {
-      console.info(`Canceling ${previousAnimation.type} animation`);
+      console.info(`Canceling previous ${previousAnimation.type} animation`);
       cancelAnimationFrame(previousAnimation.id);
+      viewer.scene.camera.lookAtTransform(Matrix4.IDENTITY);
       runAnimation(
         viewer,
         viewerAnimationMap,
@@ -155,6 +151,10 @@ export const animateCamera = (
   }
 };
 
+// TODO: figure out this bug
+// when pitch is at -Math.PI / 2 the HeadingPitchRange heading resets to 0;
+const OFFSET_NADIR = -Math.PI / 2 + 0.0001;
+
 /**
  * Get the heading and pitch for a mouse event.
  * @param event The mouse event.
@@ -179,14 +179,20 @@ export const getHeadingPitchForMouseEvent = (
   minPitch: number,
   maxPitch: number
 ) => {
+  const absoluteMinPitch = Math.max(minPitch, OFFSET_NADIR);
+  const absoluteMaxPitch = Math.min(maxPitch, 0);
   const deltaX = event.clientX - initialMouseX;
   const deltaY = event.clientY - initialMouseY;
   const headingChange = (deltaX * 0.01 * headingFactor) % CesiumMath.TWO_PI;
-  const newHeading =
-    ((initialHeading || 0) + headingChange) % CesiumMath.TWO_PI;
+  const newHeading = (initialHeading + headingChange) % CesiumMath.TWO_PI;
   // default pitch direction is same as maplibre
-  const pitchChange = (-deltaY * 0.01 * pitchFactor) % CesiumMath.TWO_PI;
-  const newPitchRaw = ((initialPitch || 0) + pitchChange) % CesiumMath.TWO_PI;
-  const newPitch = CesiumMath.clamp(newPitchRaw, minPitch, maxPitch);
+  let pitchChange = -deltaY * 0.01 * pitchFactor;
+
+  const newPitchRaw = (initialPitch + pitchChange) % CesiumMath.TWO_PI;
+  const newPitch = CesiumMath.clamp(
+    newPitchRaw,
+    absoluteMinPitch,
+    absoluteMaxPitch
+  );
   return { heading: newHeading, pitch: newPitch };
 };

--- a/libraries/mapping/engines/cesium/src/lib/utils/cesiumCamera.ts
+++ b/libraries/mapping/engines/cesium/src/lib/utils/cesiumCamera.ts
@@ -1,4 +1,4 @@
-import { Cartesian2, Viewer } from "cesium";
+import { Camera, Cartesian2, Viewer, Math as CesiumMath } from "cesium";
 
 export const getCesiumCameraPixelDimensionForDistance = (
   viewer: Viewer,
@@ -35,4 +35,24 @@ export const getCesiumCameraPixelDimensionForDistance = (
     y,
     average: (x + y) / 2,
   };
+};
+
+/**
+ * Corrects the camera's heading to account for roll when the camera's pitch is near the nadir.
+ * This adjustment prevents the heading from flipping by 180 degrees when tilting above the nadir range.
+ *
+ * @param camera - The camera from which to retrieve the heading and roll.
+ * @param nadirRange - The angular range (in radians) from the nadir within which the camera is considered to be at nadir. Default is 0.2 radians.
+ * @returns The heading adjusted for roll when near the nadir, otherwise the original heading.
+ */
+export const applyRollToHeadingForCameraNearNadir = (
+  camera: Camera,
+  nadirRange = 0.2
+) => {
+  const isInNadirRange =
+    Math.abs(camera.pitch + CesiumMath.PI_OVER_TWO) < nadirRange;
+  const rollCorrectedHeading = isInNadirRange
+    ? (camera.heading + camera.roll) % CesiumMath.TWO_PI
+    : camera.heading;
+  return rollCorrectedHeading;
 };

--- a/libraries/mapping/engines/cesium/src/lib/utils/cesiumSetup.ts
+++ b/libraries/mapping/engines/cesium/src/lib/utils/cesiumSetup.ts
@@ -1,3 +1,4 @@
+import { Viewer } from "cesium";
 import type { CesiumConfig } from "./../..";
 
 declare global {
@@ -15,4 +16,22 @@ const getDefaultBaseUrl = () => {
 export const setupCesiumEnvironment = (config?: CesiumConfig) => {
   const baseUrl = config?.baseUrl ? config.baseUrl : getDefaultBaseUrl();
   window.CESIUM_BASE_URL = baseUrl;
+};
+
+export const getIsViewerReadyAsync = async (
+  viewer: Viewer,
+  setIsViewerReady: (value: boolean) => void
+) => {
+  // checking for viewer readyness
+  // https://github.com/CesiumGS/cesium/issues/4422#issuecomment-1668233567
+  await new Promise<void>((resolve) => {
+    const removeEvent = viewer.scene.postRender.addEventListener(() => {
+      if (viewer.clockViewModel.canAnimate) {
+        console.log("Viewer is ready");
+        removeEvent();
+        setIsViewerReady(true);
+        resolve();
+      }
+    });
+  });
 };

--- a/libraries/mapping/engines/cesium/src/lib/utils/viewerAnimationMap.ts
+++ b/libraries/mapping/engines/cesium/src/lib/utils/viewerAnimationMap.ts
@@ -1,4 +1,4 @@
-import { Viewer } from "cesium";
+import { Viewer, Matrix4 } from "cesium";
 
 export enum AnimationType {
   ResetView = "ResetView",
@@ -23,8 +23,15 @@ export const cancelViewerAnimation = (
 ) => {
   const animationEntry = viewerAnimationMap.get(viewer);
   if (animationEntry) {
-    console.info(`Canceling animation of type ${animationEntry.type}`);
     cancelAnimationFrame(animationEntry.id);
+    // reset any camera transforms
+    viewer.scene.camera.lookAtTransform(Matrix4.IDENTITY);
     viewerAnimationMap.delete(viewer);
+    console.debug(
+      `Canceling animation of type ${animationEntry.type}`,
+      animationEntry.id
+    );
   }
+  // Request a render to update the scene
+  viewer.scene.requestRender();
 };

--- a/playgrounds/carmamap/src/app/components/CarmaMap/CarmaMap.tsx
+++ b/playgrounds/carmamap/src/app/components/CarmaMap/CarmaMap.tsx
@@ -195,13 +195,19 @@ export const CarmaMap = ({
   const layers = useSelector(getLayers);
   const uiMode = useSelector(getUIMode);
   const showFullscreenButton = useSelector(getShowFullscreenButton);
-  const { viewerRef, terrainProviderRef, surfaceProviderRef, tilesetsRefs } =
-    useCesiumContext();
+  const {
+    viewerRef,
+    viewerAnimationMapRef,
+    terrainProviderRef,
+    surfaceProviderRef,
+    tilesetsRefs,
+  } = useCesiumContext();
+
   const homeControl = useHomeControl();
   const {
     handleZoomIn: handleZoomInCesium,
     handleZoomOut: handleZoomOutCesium,
-  } = useZoomControlsCesium(viewerRef);
+  } = useZoomControlsCesium(viewerRef, viewerAnimationMapRef);
   const { getLeafletZoom, zoomInLeaflet, zoomOutLeaflet } =
     useLeafletZoomControls();
   const showPrimaryTileset = useSelector(selectShowPrimaryTileset);

--- a/playgrounds/cesium-reference/src/views/NavigationControl.tsx
+++ b/playgrounds/cesium-reference/src/views/NavigationControl.tsx
@@ -22,6 +22,7 @@ import {
 } from "@carma-mapping/map-controls-layout";
 
 import {
+  getIsViewerReadyAsync,
   useZoomControls,
   PitchingCompass,
   initViewerAnimationMap,
@@ -31,12 +32,10 @@ import {
 import useTileset from "../hooks/useTileset";
 import { useZoomToTilesetOnReady } from "../hooks/useZoomToTilesetOnReady";
 import { cesiumConstructorOptions } from "../config";
-
 const NavigationControlView: FC = () => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const viewerRef = useRef<Viewer | null>(null);
   const viewerAnimationMapRef = useRef<ViewerAnimationMap | null>(null);
-
   const [isViewerReady, setIsViewerReady] = useState(false);
 
   const { tilesetRef, tilesetReady } = useTileset(
@@ -64,18 +63,7 @@ const NavigationControlView: FC = () => {
         const newImageryLayer = new ImageryLayer(imageryProvider);
         viewer.imageryLayers.add(newImageryLayer);
 
-        // checking for viewer readyness
-        // https://github.com/CesiumGS/cesium/issues/4422#issuecomment-1668233567
-        await new Promise<void>((resolve) => {
-          const removeEvent = viewer.scene.postRender.addEventListener(() => {
-            if (viewer.clockViewModel.canAnimate) {
-              console.log("Viewer is ready");
-              removeEvent();
-              setIsViewerReady(true);
-              resolve();
-            }
-          });
-        });
+        await getIsViewerReadyAsync(viewer, setIsViewerReady);
       }
     };
 
@@ -90,7 +78,10 @@ const NavigationControlView: FC = () => {
   }, []);
 
   useZoomToTilesetOnReady(viewerRef, tilesetRef, tilesetReady);
-  const { handleZoomIn, handleZoomOut } = useZoomControls(viewerRef, 1);
+  const { handleZoomIn, handleZoomOut } = useZoomControls(
+    viewerRef,
+    viewerAnimationMapRef
+  );
 
   console.log("RENDER", isViewerReady);
 

--- a/playgrounds/cesium/src/app/views/tests/standalone/HQ500.tsx
+++ b/playgrounds/cesium/src/app/views/tests/standalone/HQ500.tsx
@@ -41,14 +41,15 @@ export const HQ500 = () => {
   const container3dMapRef = useRef<HTMLDivElement>(null);
 
   // State and Selectors
-  const { viewerRef, tilesetsRefs, imageryLayerRef } = useCesiumContext();
+  const { viewerRef, viewerAnimationMapRef, tilesetsRefs, imageryLayerRef } =
+    useCesiumContext();
   const viewer = viewerRef.current;
   const primaryTileset = tilesetsRefs.primaryRef.current;
   const homeControl = useHomeControl();
   const {
     handleZoomIn: handleZoomInCesium,
     handleZoomOut: handleZoomOutCesium,
-  } = useZoomControlsCesium(viewerRef);
+  } = useZoomControlsCesium(viewerRef, viewerAnimationMapRef);
 
   useTweakpaneCtx({
     folder: {


### PR DESCRIPTION
overpitching is still an issue with cesium default inputs (no regression)

(technically, pitch becomes lower than -90 deg so heading is suddenly inverted)

fixed soft roll behavior near nadir angles as side effect of that.

compass sometimes still flips with top down views, that behavior is technically correct, but should be intercepted by limiting screen space interaction pitch angle to -0 to -90 range.
(e. g. With normal built in mouse dragging pitch change, the pitch can co under -90 deg into -91 at nadir positions)
Would need new hard limiter handling for that.

Zoom handling improved to animations.
Zoom and Compass UI triggered animations can cancel each other. 