### PR TITLE
store url param updates in weakmap

### DIFF
--- a/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
+++ b/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
@@ -34,8 +34,9 @@ import {
 import { getApplicationVersion } from "@carma-commons/utils";
 
 import {
+  cesiumCameraParamsKeyList,
+  cesiumClearParamKeys,
   CustomViewer,
-  getClearCesiumCameraParams,
   selectCurrentSceneStyle,
   selectShowPrimaryTileset,
   selectViewerIsMode2d,
@@ -43,6 +44,7 @@ import {
   setCurrentSceneStyle,
   useCesiumContext,
   useCesiumInitialCameraFromSearchParams,
+  VIEWERSTATE_KEYS,
 } from "@carma-mapping/cesium-engine";
 import { EmptySearchComponent } from "@carma-mapping/fuzzy-search";
 
@@ -91,8 +93,6 @@ interface MapProps {
   width: number;
   allow3d?: boolean;
 }
-
-const clear3dParams = getClearCesiumCameraParams();
 
 export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
   const dispatch = useDispatch();
@@ -355,16 +355,16 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
 
     const newParams = {
       ...currentParams,
-      ...clear3dParams,
-      m: sceneStyle,
+      [VIEWERSTATE_KEYS.mapStyle]: sceneStyle,
       lat: latTruncated,
       lng: lngTruncated,
       zoom: zoomString,
     };
 
     replaceHashRoutedHistory(
-      { hashParams: newParams },
+      newParams,
       pathname,
+      cesiumClearParamKeys,
       "GPM:TopicMap:locationChangedHandler"
     );
   };
@@ -376,7 +376,7 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
       );
       return;
     }
-    replaceHashRoutedHistory(e, pathname, "GPM:3D");
+    replaceHashRoutedHistory(e.hashParams, pathname, ["zoom"], "GPM:3D");
   };
 
   // TODO Move out Controls to own component

--- a/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
+++ b/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
@@ -10,8 +10,6 @@ import TopicMapComponent from "react-cismap/topicmaps/TopicMapComponent";
 import GenericModalApplicationMenu from "react-cismap/topicmaps/menu/ModalApplicationMenu";
 
 import {
-  getHashParams,
-  replaceHashRoutedHistory,
   TopicMapSelectionContent,
   useCarmaMapContext,
   useGazData,
@@ -31,10 +29,13 @@ import {
   OverlayTourContext,
   useOverlayHelper,
 } from "@carma-commons/ui/lib-helper-overlay";
-import { getApplicationVersion } from "@carma-commons/utils";
+import {
+  getApplicationVersion,
+  getHashParams,
+  updateHashHistoryState,
+} from "@carma-commons/utils";
 
 import {
-  cesiumCameraParamsKeyList,
   cesiumClearParamKeys,
   CustomViewer,
   selectCurrentSceneStyle,
@@ -361,7 +362,7 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
       zoom: zoomString,
     };
 
-    replaceHashRoutedHistory(
+    updateHashHistoryState(
       newParams,
       pathname,
       cesiumClearParamKeys,
@@ -376,7 +377,7 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
       );
       return;
     }
-    replaceHashRoutedHistory(e.hashParams, pathname, ["zoom"], "GPM:3D");
+    updateHashHistoryState(e.hashParams, pathname, ["zoom"], "GPM:3D");
   };
 
   // TODO Move out Controls to own component

--- a/apps/geoportal/src/app/components/GeoportalMap/LibreGeoportalMap.tsx
+++ b/apps/geoportal/src/app/components/GeoportalMap/LibreGeoportalMap.tsx
@@ -6,16 +6,17 @@ import type {
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { useEffect, useRef, useState } from "react";
-import { useSearchParams } from "react-router-dom";
 
 import { useDispatch, useSelector } from "react-redux";
+
+import { getHashParams, updateHashHistoryState } from "@carma-commons/utils";
+
 import { defaultLayerConfig } from "../../config";
 import {
   getBackgroundLayer,
   getLayers,
   setLibreMapRef,
 } from "../../store/slices/mapping";
-import "./LibreGeoportalMap.css";
 import { getCoordinates } from "./topicmap.utils";
 import proj4 from "proj4";
 import { proj4crs25832def } from "react-cismap/constants/gis";
@@ -26,13 +27,16 @@ import {
 import { setSelectedFeature } from "../../store/slices/features";
 import store from "../../store";
 import { createFeature, layersToMapLibreStyle } from "./libremap.utils";
+import "./LibreGeoportalMap.css";
+import { useLocation } from "react-router-dom";
+import path from "path";
 
 const LibreGeoportalMap = () => {
   const dispatch = useDispatch();
+  const { pathname } = useLocation();
 
   const mapContainer = useRef<HTMLDivElement>(null);
   const map = useRef<maplibregl.Map | null>(null);
-  const [searchParams, setSearchParams] = useSearchParams();
   const selectedFeatures: Set<{
     source: string;
     sourceLayer: string;
@@ -71,28 +75,36 @@ const LibreGeoportalMap = () => {
   useEffect(() => {
     if (map.current) return; // initialize map only once
 
+    const hashParams = getHashParams();
+
     if (mapContainer.current) {
-      const lng = searchParams.get("lng")
-        ? parseFloat(searchParams.get("lng"))
-        : defaultLng;
-      const lat = searchParams.get("lat")
-        ? parseFloat(searchParams.get("lat"))
-        : defaultLat;
+      const lng =
+        hashParams["lng"] !== undefined
+          ? parseFloat(hashParams["lng"])
+          : defaultLng;
+
+      const lat =
+        hashParams["lat"] !== undefined
+          ? parseFloat(hashParams["lat"])
+          : defaultLat;
       map.current = new maplibregl.Map({
         container: mapContainer.current,
         style: backgroundStyle,
         center: [lng, lat],
-        zoom: searchParams.get("zoom")
-          ? parseFloat(searchParams.get("zoom")) - 1
-          : defaultZoom,
+        zoom:
+          hashParams["zoom"] !== undefined
+            ? parseFloat(hashParams["zoom"]) - 1
+            : defaultZoom,
         maxZoom: 21,
         minZoom: 9,
-        pitch: searchParams.get("pitch")
-          ? parseFloat(searchParams.get("pitch"))
-          : 0,
-        bearing: searchParams.get("heading")
-          ? parseFloat(searchParams.get("heading"))
-          : 0,
+        pitch:
+          hashParams["pitch"] !== undefined
+            ? parseFloat(hashParams["pitch"])
+            : 0,
+        bearing:
+          hashParams["heading"] !== undefined
+            ? parseFloat(hashParams["heading"])
+            : 0,
         maxPitch: 85,
       });
 
@@ -279,13 +291,14 @@ const LibreGeoportalMap = () => {
       const pitch = mapInstance.getPitch();
       const bearing = mapInstance.getBearing();
 
-      const newParams = new URLSearchParams(searchParams);
-      newParams.set("lng", center.lng.toFixed(14));
-      newParams.set("lat", center.lat.toFixed(14));
-      newParams.set("zoom", (zoom + 1).toFixed(0));
-      newParams.set("pitch", pitch.toFixed(2));
-      newParams.set("heading", bearing.toFixed(1));
-      setSearchParams(newParams);
+      const newParams = {
+        lng: center.lng.toFixed(8),
+        lat: center.lat.toFixed(8),
+        zoom: (zoom + 1).toFixed(0),
+        pitch: pitch.toFixed(2),
+        heading: bearing.toFixed(1),
+      };
+      updateHashHistoryState(newParams, pathname, [], "MapLibre");
     };
 
     mapInstance.on("moveend", handleMoveEnd);
@@ -293,7 +306,7 @@ const LibreGeoportalMap = () => {
     return () => {
       mapInstance.off("moveend", handleMoveEnd);
     };
-  }, [searchParams, setSearchParams]);
+  }, [pathname]);
 
   useEffect(() => {
     if (!map.current) return;

--- a/apps/geoportal/src/app/components/GeoportalMap/controls/MapWrapper.tsx
+++ b/apps/geoportal/src/app/components/GeoportalMap/controls/MapWrapper.tsx
@@ -28,7 +28,6 @@ import { TopicMapContext } from "react-cismap/contexts/TopicMapContextProvider";
 import { ResponsiveTopicMapContext } from "react-cismap/contexts/ResponsiveTopicMapContextProvider";
 
 import {
-  replaceHashRoutedHistory,
   SelectionMetaData,
   useFeatureFlags,
   useGazData,
@@ -37,7 +36,10 @@ import {
 
 import { useTweakpaneCtx } from "@carma-commons/debug";
 import { ENDPOINT, isAreaType } from "@carma-commons/resources";
-import { detectWebGLContext } from "@carma-commons/utils";
+import {
+  deleteHashParamsFromHistoryState,
+  detectWebGLContext,
+} from "@carma-commons/utils";
 
 import {
   cesiumClearParamKeys,
@@ -260,10 +262,9 @@ const MapWrapper = () => {
 
   const clear3dHashParams = () => {
     console.debug("[CESIUM|DEBUG] MapTypeSwitcher: 2D mode, clear hash params");
-    replaceHashRoutedHistory(
-      {},
-      pathname,
+    deleteHashParamsFromHistoryState(
       cesiumClearParamKeys,
+      pathname,
       "MapTypeSwitcher Clear"
     );
   };

--- a/apps/geoportal/src/app/components/GeoportalMap/controls/MapWrapper.tsx
+++ b/apps/geoportal/src/app/components/GeoportalMap/controls/MapWrapper.tsx
@@ -40,7 +40,7 @@ import { ENDPOINT, isAreaType } from "@carma-commons/resources";
 import { detectWebGLContext } from "@carma-commons/utils";
 
 import {
-  getClearCesiumCameraParams,
+  cesiumClearParamKeys,
   MapTypeSwitcher,
   PitchingCompass,
   selectViewerIsMode2d,
@@ -111,8 +111,6 @@ let hasGPU = false;
 const setHasGPU = (flag: boolean) => (hasGPU = flag);
 const testGPU = () => detectWebGLContext(setHasGPU);
 window.addEventListener("load", testGPU, false);
-
-const clear3dHashParamsObject = getClearCesiumCameraParams();
 
 // TODO: centralize the hash params update behavior
 
@@ -263,8 +261,9 @@ const MapWrapper = () => {
   const clear3dHashParams = () => {
     console.debug("[CESIUM|DEBUG] MapTypeSwitcher: 2D mode, clear hash params");
     replaceHashRoutedHistory(
-      { hashParams: clear3dHashParamsObject },
+      {},
       pathname,
+      cesiumClearParamKeys,
       "MapTypeSwitcher Clear"
     );
   };

--- a/apps/geoportal/src/app/hooks/useAppConfig.ts
+++ b/apps/geoportal/src/app/hooks/useAppConfig.ts
@@ -1,14 +1,15 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
-import { useSearchParams } from "react-router-dom";
+import { useLocation, useSearchParams } from "react-router-dom";
 
 import {
-  BackgroundLayer,
-  getHashParams,
-  LayerMap,
-  Settings,
+  type BackgroundLayer,
+  type LayerMap,
+  type SelectionItem,
+  type Settings,
+  replaceHashRoutedHistory,
 } from "@carma-apps/portals";
-import { Layer } from "@carma-mapping/layers";
+import { type Layer } from "@carma-mapping/layers";
 
 import {
   setBackgroundLayer,
@@ -19,7 +20,6 @@ import {
 } from "../store/slices/mapping";
 
 import { AppDispatch } from "../store";
-import { SelectionItem } from "@carma-apps/portals";
 
 type View = {
   center: string[];
@@ -33,6 +33,8 @@ type Config = {
   view?: View;
   selection?: SelectionItem;
 };
+
+const CONFIG_KEY = "config";
 
 const onLoadedConfig = (
   config: Config,
@@ -75,8 +77,8 @@ const onLoadedConfig = (
 export const useAppConfig = (configBaseUrl: string, layerMap: LayerMap) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const dispatch = useDispatch();
-  const currentParams = getHashParams();
-  const config = currentParams.config;
+  const { pathname } = useLocation();
+  const config = searchParams.get(CONFIG_KEY);
   const [isLoadingConfig, setIsLoadingConfig] = useState(false);
 
   useEffect(() => {
@@ -88,9 +90,16 @@ export const useAppConfig = (configBaseUrl: string, layerMap: LayerMap) => {
       .then((response) => response.json())
       .then((newConfig: Config) => {
         onLoadedConfig(newConfig, layerMap, dispatch);
-        searchParams.delete("config");
+        searchParams.delete(CONFIG_KEY);
+
         setSearchParams(searchParams);
         setIsLoadingConfig(false);
+        replaceHashRoutedHistory(
+          {},
+          pathname,
+          [CONFIG_KEY],
+          "load config, remove key after evaluation"
+        );
       })
       .catch((error) => {
         if (error.name === "AbortError") return;

--- a/apps/geoportal/src/app/hooks/useAppConfig.ts
+++ b/apps/geoportal/src/app/hooks/useAppConfig.ts
@@ -1,13 +1,12 @@
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
-import { useLocation, useSearchParams } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 import {
   type BackgroundLayer,
   type LayerMap,
   type SelectionItem,
   type Settings,
-  replaceHashRoutedHistory,
 } from "@carma-apps/portals";
 import { type Layer } from "@carma-mapping/layers";
 
@@ -20,6 +19,10 @@ import {
 } from "../store/slices/mapping";
 
 import { AppDispatch } from "../store";
+import {
+  deleteHashParamsFromHistoryState,
+  getHashParams,
+} from "@carma-commons/utils";
 
 type View = {
   center: string[];
@@ -75,13 +78,13 @@ const onLoadedConfig = (
 };
 
 export const useAppConfig = (configBaseUrl: string, layerMap: LayerMap) => {
-  const [searchParams, setSearchParams] = useSearchParams();
   const dispatch = useDispatch();
   const { pathname } = useLocation();
-  const config = searchParams.get(CONFIG_KEY);
   const [isLoadingConfig, setIsLoadingConfig] = useState(false);
 
   useEffect(() => {
+    const hashParams = getHashParams();
+    const config = hashParams[CONFIG_KEY];
     if (!config) return;
     setIsLoadingConfig(true);
     const controller = new AbortController();
@@ -90,15 +93,11 @@ export const useAppConfig = (configBaseUrl: string, layerMap: LayerMap) => {
       .then((response) => response.json())
       .then((newConfig: Config) => {
         onLoadedConfig(newConfig, layerMap, dispatch);
-        searchParams.delete(CONFIG_KEY);
-
-        setSearchParams(searchParams);
         setIsLoadingConfig(false);
-        replaceHashRoutedHistory(
-          {},
-          pathname,
+        deleteHashParamsFromHistoryState(
           [CONFIG_KEY],
-          "load config, remove key after evaluation"
+          pathname,
+          "remove config postinit"
         );
       })
       .catch((error) => {

--- a/apps/geoportal/src/app/hooks/useCesiumSearchParams.ts
+++ b/apps/geoportal/src/app/hooks/useCesiumSearchParams.ts
@@ -5,14 +5,15 @@ import { useDispatch } from "react-redux";
 import {
   setIsMode2d,
   setCurrentSceneStyle,
+  VIEWERSTATE_KEYS,
 } from "@carma-mapping/cesium-engine";
 
 export const useCesiumSearchParams = () => {
   const [searchParams] = useSearchParams();
   const dispatch = useDispatch();
   useEffect(() => {
-    if (searchParams.has("is3d")) {
-      const is3d = searchParams.get("is3d");
+    if (searchParams.has(VIEWERSTATE_KEYS.is3d)) {
+      const is3d = searchParams.get(VIEWERSTATE_KEYS.is3d);
       if (is3d === "1") {
         dispatch(setIsMode2d(false));
       } else {
@@ -21,8 +22,9 @@ export const useCesiumSearchParams = () => {
     }
 
     // TODO: handle this in common hook with TopicMap basemap setting on start from URL
-    if (searchParams.has("m")) {
-      const isPrimaryStyle = searchParams.get("m") === "1";
+    if (searchParams.has(VIEWERSTATE_KEYS.mapStyle)) {
+      const isPrimaryStyle =
+        searchParams.get(VIEWERSTATE_KEYS.mapStyle) === "1";
       dispatch(setCurrentSceneStyle(isPrimaryStyle ? "primary" : "secondary"));
     }
     // run only once on load

--- a/apps/geoportal/src/app/hooks/useCesiumSearchParams.ts
+++ b/apps/geoportal/src/app/hooks/useCesiumSearchParams.ts
@@ -1,5 +1,4 @@
 import { useEffect } from "react";
-import { useSearchParams } from "react-router-dom";
 import { useDispatch } from "react-redux";
 
 import {
@@ -7,24 +6,24 @@ import {
   setCurrentSceneStyle,
   VIEWERSTATE_KEYS,
 } from "@carma-mapping/cesium-engine";
+import { getHashParams } from "@carma-commons/utils";
 
 export const useCesiumSearchParams = () => {
-  const [searchParams] = useSearchParams();
   const dispatch = useDispatch();
   useEffect(() => {
-    if (searchParams.has(VIEWERSTATE_KEYS.is3d)) {
-      const is3d = searchParams.get(VIEWERSTATE_KEYS.is3d);
+    const hashParams = getHashParams();
+
+    if (hashParams[VIEWERSTATE_KEYS.is3d] !== undefined) {
+      const is3d = hashParams[VIEWERSTATE_KEYS.is3d];
       if (is3d === "1") {
         dispatch(setIsMode2d(false));
-      } else {
-        dispatch(setIsMode2d(true));
       }
+    } else {
+      dispatch(setIsMode2d(true));
     }
-
     // TODO: handle this in common hook with TopicMap basemap setting on start from URL
-    if (searchParams.has(VIEWERSTATE_KEYS.mapStyle)) {
-      const isPrimaryStyle =
-        searchParams.get(VIEWERSTATE_KEYS.mapStyle) === "1";
+    if (hashParams[VIEWERSTATE_KEYS.mapStyle] !== undefined) {
+      const isPrimaryStyle = hashParams[VIEWERSTATE_KEYS.mapStyle] === "1";
       dispatch(setCurrentSceneStyle(isPrimaryStyle ? "primary" : "secondary"));
     }
     // run only once on load

--- a/apps/geoportal/src/app/hooks/useSyncToken.ts
+++ b/apps/geoportal/src/app/hooks/useSyncToken.ts
@@ -1,12 +1,21 @@
+import { getHashParams } from "@carma-commons/utils";
 import { useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+
+const SYNC_HASHPARAM_KEY = "sync";
 
 export const useSyncToken = () => {
-  const [searchParams] = useSearchParams();
   const [syncToken, setSyncToken] = useState(null);
   useEffect(() => {
-    if (searchParams.get("sync")) {
-      setSyncToken(searchParams.get("sync"));
+    const hashParams = getHashParams();
+    if (hashParams[SYNC_HASHPARAM_KEY] !== undefined) {
+      const syncTokenString = hashParams[SYNC_HASHPARAM_KEY];
+      if (
+        syncTokenString !== null &&
+        syncTokenString !== undefined &&
+        syncTokenString.trim().length > 0
+      ) {
+        setSyncToken(syncToken);
+      }
     }
     // run only once on load
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/envirometrics/wuppertal/floodingmap/src/App.tsx
+++ b/envirometrics/wuppertal/floodingmap/src/App.tsx
@@ -17,7 +17,6 @@ import CrossTabCommunicationControl from "react-cismap/CrossTabCommunicationCont
 import { TopicMapContext } from "react-cismap/contexts/TopicMapContextProvider";
 
 import {
-  replaceHashRoutedHistory,
   SelectionMetaData,
   TopicMapSelectionContent,
   useGazData,
@@ -30,7 +29,10 @@ import {
   isAreaType,
   isAreaTypeWithGEP,
 } from "@carma-commons/resources";
-import { getApplicationVersion } from "@carma-commons/utils";
+import {
+  getApplicationVersion,
+  updateHashHistoryState,
+} from "@carma-commons/utils";
 
 import { getCollabedHelpComponentConfig } from "@carma-collab/wuppertal/hochwassergefahrenkarte";
 
@@ -172,7 +174,7 @@ function App({ sync = false }: { sync?: boolean }) {
   const onCesiumSceneChange = (e) => {
     isMode2d
       ? undefined
-      : replaceHashRoutedHistory(e.hashParams, "/", ["zoom"], "app/hgk:3D");
+      : updateHashHistoryState(e.hashParams, "/", ["zoom"], "app/hgk:3D");
   };
 
   useSelectionTopicMap();

--- a/envirometrics/wuppertal/floodingmap/src/App.tsx
+++ b/envirometrics/wuppertal/floodingmap/src/App.tsx
@@ -47,6 +47,7 @@ import {
   useCesiumInitialCameraFromSearchParams,
   useHomeControl,
   useZoomControls,
+  VIEWERSTATE_KEYS,
 } from "@carma-mapping/cesium-engine";
 import {
   EmptySearchComponent,
@@ -169,7 +170,9 @@ function App({ sync = false }: { sync?: boolean }) {
   };
 
   const onCesiumSceneChange = (e) => {
-    isMode2d ? undefined : replaceHashRoutedHistory(e, "/", "app/hgk");
+    isMode2d
+      ? undefined
+      : replaceHashRoutedHistory(e.hashParams, "/", ["zoom"], "app/hgk:3D");
   };
 
   useSelectionTopicMap();
@@ -188,8 +191,8 @@ function App({ sync = false }: { sync?: boolean }) {
   );
 
   useEffect(() => {
-    if (searchParams.has("is3d")) {
-      const is3d = searchParams.get("is3d") === "1";
+    if (searchParams.has(VIEWERSTATE_KEYS.is3d)) {
+      const is3d = searchParams.get(VIEWERSTATE_KEYS.is3d) === "1";
       dispatch(setIsMode2d(!is3d));
     }
     // run only once on load

--- a/libraries/appframeworks/portals/src/index.ts
+++ b/libraries/appframeworks/portals/src/index.ts
@@ -7,7 +7,6 @@ export enum SELECTED_LAYER_INDEX {
 }
 
 export { utils };
-export { replaceHashRoutedHistory, getHashParams } from "./lib/utils/routing";
 
 export {
   FeatureFlagProvider,

--- a/libraries/appframeworks/portals/src/lib/components/FeatureFlagProvider.tsx
+++ b/libraries/appframeworks/portals/src/lib/components/FeatureFlagProvider.tsx
@@ -1,6 +1,6 @@
 // src/contexts/FeatureFlagProvider.tsx
+import { getHashParams } from "@carma-commons/utils";
 import React, { createContext, useContext, useMemo } from "react";
-import { useSearchParams } from "react-router-dom";
 
 const DEFAULT_FEATURE_FLAG_PARAM = "ff";
 const FEATURE_FLAG_DISABLED_PREFIX = "-";
@@ -36,10 +36,9 @@ export const FeatureFlagProvider: React.FC<FeatureFlagProviderProps> = ({
   config,
   featureFlagParam: featureFlagParam = DEFAULT_FEATURE_FLAG_PARAM,
 }) => {
-  const [searchParams] = useSearchParams();
-
   const flags = useMemo(() => {
-    const ffParam = searchParams.get(featureFlagParam);
+    const hashParams = getHashParams();
+    const ffParam = hashParams[featureFlagParam];
     const enabledFlags = ffParam ? ffParam.split(FEATURE_FLAG_SEPARATOR) : [];
 
     const urlFlags = Object.entries(config).reduce(
@@ -63,7 +62,7 @@ export const FeatureFlagProvider: React.FC<FeatureFlagProviderProps> = ({
     );
 
     return { ...defaultFlags, ...urlFlags };
-  }, [config, featureFlagParam, searchParams]);
+  }, [config, featureFlagParam]);
 
   return (
     <FeatureFlagContext.Provider value={flags}>

--- a/libraries/appframeworks/portals/src/lib/components/Share.tsx
+++ b/libraries/appframeworks/portals/src/lib/components/Share.tsx
@@ -3,12 +3,11 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useCopyToClipboard } from "@uidotdev/usehooks";
 import { Button, Checkbox, Radio, Tooltip, message } from "antd";
 import { useState } from "react";
-import { useSearchParams } from "react-router-dom";
 import type { LayerState, Settings } from "../types";
 import { faCopy } from "@fortawesome/free-regular-svg-icons";
 import { useFeatureFlags } from "./FeatureFlagProvider";
 import { SelectionItem } from "./SelectionProvider";
-import { getHashParams } from "../utils/routing";
+import { getHashParams } from "@carma-commons/utils";
 
 export type ShareProps = {
   layerState: LayerState;

--- a/libraries/appframeworks/portals/src/lib/utils/routing.ts
+++ b/libraries/appframeworks/portals/src/lib/utils/routing.ts
@@ -34,47 +34,45 @@ export const getHashParams = (
  * Updates the URL hash parameters without triggering a React Router navigation
  */
 export const replaceHashRoutedHistory = (
-  { hashParams }: EncodedSceneParams,
+  hashParams: Record<string, string> = {},
   routedPath: string,
+  removeKeys: string[] = [],
   label: string = "N/A" // for tracing debugging only
 ) => {
   // this is method is used to avoid triggering rerenders from the HashRouter when updating the hash
-  if (hashParams) {
-    const currentParams = getHashParams();
+  const currentParams = getHashParams();
 
-    const combinedParams: Record<string, string> = {
-      ...currentParams,
-      ...hashParams, // overwrite from state but keep others
-    };
+  const combinedParams: Record<string, string> = {
+    ...currentParams,
+    ...hashParams, // overwrite from state but keep others
+  };
 
-    // remove empty values
-    // be aware this disables "boolean" keys without a value
-    Object.entries(combinedParams).forEach(([key, value]) => {
-      if (value?.trim?.() === "") {
-        delete combinedParams[key];
-      }
-    });
+  // remove keys that are in the removeKeys array
+  removeKeys.forEach((key) => {
+    if (key in combinedParams) {
+      delete combinedParams[key];
+    }
+  });
 
-    // Store the combined parameters in our WeakMap
-    currentHashParamsStore.set(window, { ...combinedParams });
+  // Store the combined parameters in our WeakMap
+  currentHashParamsStore.set(window, { ...combinedParams });
 
-    const combinedSearchParams = new URLSearchParams(combinedParams);
-    const combinedHash = combinedSearchParams.toString();
-    const fullHashState = `#${routedPath}?${combinedHash}`;
-    // this is a workaround to avoid triggering rerenders from the HashRouter
-    // navigate would cause rerenders
-    // navigate(`${routedPath}?${formattedHash}`, { replace: true });
-    // see https://github.com/remix-run/react-router/discussions/9851#discussioncomment-9459061
+  const combinedSearchParams = new URLSearchParams(combinedParams);
+  const combinedHash = combinedSearchParams.toString();
+  const fullHashState = `#${routedPath}?${combinedHash}`;
+  // this is a workaround to avoid triggering rerenders from the HashRouter
+  // navigate would cause rerenders
+  // navigate(`${routedPath}?${formattedHash}`, { replace: true });
+  // see https://github.com/remix-run/react-router/discussions/9851#discussioncomment-9459061
 
-    const currentUrl = new URL(window.location.href);
-    const newUrl = `${currentUrl.origin}${currentUrl.pathname}${fullHashState}`;
+  const currentUrl = new URL(window.location.href);
+  const newUrl = `${currentUrl.origin}${currentUrl.pathname}${fullHashState}`;
 
-    window.history.replaceState(null, "", newUrl);
-    console.debug(
-      `[Routing] Hash parameters updated (${label}):`,
-      combinedParams
-    );
-  }
+  window.history.replaceState(null, "", newUrl);
+  console.debug(
+    `[Routing] Hash parameters updated (${label}):`,
+    combinedParams
+  );
 };
 
 /**

--- a/libraries/appframeworks/portals/src/lib/utils/routing.ts
+++ b/libraries/appframeworks/portals/src/lib/utils/routing.ts
@@ -3,13 +3,36 @@ type EncodedSceneParams = {
   state?: unknown;
 };
 
+// Using a singleton pattern to store the current hash parameters
+// We use a WeakMap with window as key to ensure it's garbage collected if needed
+const currentHashParamsStore: WeakMap<
+  Window,
+  Record<string, string>
+> = new WeakMap();
+
+/**
+ * Get the stored parameters or parse them from the URL as fallback
+ */
 export const getHashParams = (
   hash = window.location.hash.split("?")[1] || ""
-) => {
-  const params = Object.fromEntries(new URLSearchParams(hash));
-  return params;
+): Record<string, string> => {
+  try {
+    // Check if we have stored parameters first
+    if (currentHashParamsStore.has(window)) {
+      return { ...currentHashParamsStore.get(window) };
+    }
+
+    // Fallback to parsing from URL
+    return Object.fromEntries(new URLSearchParams(hash));
+  } catch (error) {
+    console.debug("Error parsing hash parameters:", error);
+    return {};
+  }
 };
 
+/**
+ * Updates the URL hash parameters without triggering a React Router navigation
+ */
 export const replaceHashRoutedHistory = (
   { hashParams }: EncodedSceneParams,
   routedPath: string,
@@ -18,6 +41,7 @@ export const replaceHashRoutedHistory = (
   // this is method is used to avoid triggering rerenders from the HashRouter when updating the hash
   if (hashParams) {
     const currentParams = getHashParams();
+
     const combinedParams: Record<string, string> = {
       ...currentParams,
       ...hashParams, // overwrite from state but keep others
@@ -26,14 +50,16 @@ export const replaceHashRoutedHistory = (
     // remove empty values
     // be aware this disables "boolean" keys without a value
     Object.entries(combinedParams).forEach(([key, value]) => {
-      if (value.trim() === "") {
+      if (value?.trim?.() === "") {
         delete combinedParams[key];
       }
     });
 
+    // Store the combined parameters in our WeakMap
+    currentHashParamsStore.set(window, { ...combinedParams });
+
     const combinedSearchParams = new URLSearchParams(combinedParams);
     const combinedHash = combinedSearchParams.toString();
-    //const formattedHash = combinedHash.replace(/=&/g, "&").replace(/=$/, ""); // remove empty values
     const fullHashState = `#${routedPath}?${combinedHash}`;
     // this is a workaround to avoid triggering rerenders from the HashRouter
     // navigate would cause rerenders
@@ -44,5 +70,31 @@ export const replaceHashRoutedHistory = (
     const newUrl = `${currentUrl.origin}${currentUrl.pathname}${fullHashState}`;
 
     window.history.replaceState(null, "", newUrl);
+    console.debug(
+      `[Routing] Hash parameters updated (${label}):`,
+      combinedParams
+    );
+  }
+};
+
+/**
+ * Synchronizes the internal parameter store with the current URL
+ * Call this when you know the URL has been changed externally (e.g., by user navigation)
+ */
+export const syncParamsWithUrl = (): void => {
+  const urlParams = Object.fromEntries(
+    new URLSearchParams(window.location.hash.split("?")[1] || "")
+  );
+  currentHashParamsStore.set(window, urlParams);
+  console.debug("[Routing] Parameters synced from URL:", urlParams);
+};
+
+/**
+ * Clears the stored parameters, forcing fallback to URL parsing
+ */
+export const clearStoredParams = (): void => {
+  if (currentHashParamsStore.has(window)) {
+    currentHashParamsStore.delete(window);
+    console.debug("[Routing] Cleared stored parameters");
   }
 };

--- a/libraries/appframeworks/portals/tsconfig.lib.json
+++ b/libraries/appframeworks/portals/tsconfig.lib.json
@@ -5,6 +5,6 @@
     "declaration": true,
     "types": ["node", "vite/client"]
   },
-  "include": ["src/index.ts", "src/lib/**/*.ts", "src/lib/**/*.tsx", "src/lib/**/*.js", "src/lib/**/*.jsx"],
+  "include": ["src/index.ts", "src/lib/**/*.ts", "src/lib/**/*.tsx", "src/lib/**/*.js", "src/lib/**/*.jsx", "../../commons/utils/src/lib/routing.ts"],
   "exclude": ["vite.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/libraries/commons/utils/src/index.ts
+++ b/libraries/commons/utils/src/index.ts
@@ -21,6 +21,12 @@ export {
   convertBBox2Bounds,
 } from "./lib/proj4helpers";
 
+export {
+  updateHashHistoryState,
+  deleteHashParamsFromHistoryState,
+  getHashParams,
+} from "./lib/routing.ts";
+
 export { generateRandomString } from "./lib/strings";
 
 export { getApplicationVersion } from "./lib/version";

--- a/libraries/commons/utils/src/lib/routing.ts
+++ b/libraries/commons/utils/src/lib/routing.ts
@@ -1,14 +1,6 @@
-type EncodedSceneParams = {
-  hashParams: Record<string, string>;
-  state?: unknown;
-};
-
 // Using a singleton pattern to store the current hash parameters
 // We use a WeakMap with window as key to ensure it's garbage collected if needed
-const currentHashParamsStore: WeakMap<
-  Window,
-  Record<string, string>
-> = new WeakMap();
+const hashStore: WeakMap<Window, Record<string, string>> = new WeakMap();
 
 /**
  * Get the stored parameters or parse them from the URL as fallback
@@ -18,8 +10,8 @@ export const getHashParams = (
 ): Record<string, string> => {
   try {
     // Check if we have stored parameters first
-    if (currentHashParamsStore.has(window)) {
-      return { ...currentHashParamsStore.get(window) };
+    if (hashStore.has(window)) {
+      return { ...hashStore.get(window) };
     }
 
     // Fallback to parsing from URL
@@ -33,7 +25,7 @@ export const getHashParams = (
 /**
  * Updates the URL hash parameters without triggering a React Router navigation
  */
-export const replaceHashRoutedHistory = (
+export const updateHashHistoryState = (
   hashParams: Record<string, string> = {},
   routedPath: string,
   removeKeys: string[] = [],
@@ -55,7 +47,7 @@ export const replaceHashRoutedHistory = (
   });
 
   // Store the combined parameters in our WeakMap
-  currentHashParamsStore.set(window, { ...combinedParams });
+  hashStore.set(window, { ...combinedParams });
 
   const combinedSearchParams = new URLSearchParams(combinedParams);
   const combinedHash = combinedSearchParams.toString();
@@ -76,6 +68,17 @@ export const replaceHashRoutedHistory = (
 };
 
 /**
+ * Replaces the current URL hash with a new one, preserving the existing parameters
+ */
+export const deleteHashParamsFromHistoryState = (
+  keys: string[],
+  routedPath: string,
+  label: string = "N/A" // for tracing debugging only
+): void => {
+  updateHashHistoryState({}, routedPath, keys, label);
+};
+
+/**
  * Synchronizes the internal parameter store with the current URL
  * Call this when you know the URL has been changed externally (e.g., by user navigation)
  */
@@ -83,7 +86,7 @@ export const syncParamsWithUrl = (): void => {
   const urlParams = Object.fromEntries(
     new URLSearchParams(window.location.hash.split("?")[1] || "")
   );
-  currentHashParamsStore.set(window, urlParams);
+  hashStore.set(window, urlParams);
   console.debug("[Routing] Parameters synced from URL:", urlParams);
 };
 
@@ -91,8 +94,8 @@ export const syncParamsWithUrl = (): void => {
  * Clears the stored parameters, forcing fallback to URL parsing
  */
 export const clearStoredParams = (): void => {
-  if (currentHashParamsStore.has(window)) {
-    currentHashParamsStore.delete(window);
+  if (hashStore.has(window)) {
+    hashStore.delete(window);
     console.debug("[Routing] Cleared stored parameters");
   }
 };

--- a/libraries/mapping/engines/cesium/src/index.ts
+++ b/libraries/mapping/engines/cesium/src/index.ts
@@ -30,6 +30,7 @@ export { useFovWheelZoom } from "./lib/hooks/useFovWheelZoom";
 export { useSceneStyles } from "./lib/hooks/useSceneStyles";
 export { useZoomControls } from "./lib/hooks/useZoomControls";
 
+export { VIEWERSTATE_KEYS } from "./lib/constants";
 export { CUSTOM_SHADERS_DEFINITIONS } from "./lib/shaders";
 
 // TODO: all the utils used elsewhere with no cesium dedependency should be moved to common helper utils lib
@@ -51,8 +52,8 @@ export { applyRollToHeadingForCameraNearNadir } from "./lib/utils/cesiumCamera";
 export {
   encodeCesiumCamera,
   decodeCesiumCamera,
-  cesiumCameraParamsKeyList,
-  getClearCesiumCameraParams,
+  cesiumCameraParamKeys,
+  cesiumClearParamKeys,
 } from "./lib/utils/cesiumHashParamsCodec";
 
 export {

--- a/libraries/mapping/engines/cesium/src/lib/constants.ts
+++ b/libraries/mapping/engines/cesium/src/lib/constants.ts
@@ -1,0 +1,4 @@
+export const VIEWERSTATE_KEYS = {
+  mapStyle: "m",
+  is3d: "is3d",
+};

--- a/libraries/mapping/engines/cesium/src/lib/hooks/useCesiumInitialCameraFromSearchParams.ts
+++ b/libraries/mapping/engines/cesium/src/lib/hooks/useCesiumInitialCameraFromSearchParams.ts
@@ -1,17 +1,17 @@
 import { useEffect, useState } from "react";
 import { decodeCesiumCamera } from "../utils/cesiumHashParamsCodec";
-import { useSearchParams } from "react-router-dom";
 import { InitialCameraView } from "../CustomViewer";
+import { getHashParams } from "@carma-commons/utils";
 
 // null means not set, undefined means no camera view found
 export const useCesiumInitialCameraFromSearchParams = () => {
-  const [searchParams] = useSearchParams();
   const [initialCameraView, setInitialCameraView] = useState<
     InitialCameraView | undefined | null
   >(null);
 
   useEffect(() => {
-    const view = decodeCesiumCamera(searchParams);
+    const hashParams = getHashParams();
+    const view = decodeCesiumCamera(hashParams);
     if (view && initialCameraView === null) {
       setInitialCameraView(view);
     } else {

--- a/libraries/mapping/engines/cesium/src/lib/hooks/useOnSceneChange.ts
+++ b/libraries/mapping/engines/cesium/src/lib/hooks/useOnSceneChange.ts
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 import { useSelector } from "react-redux";
-
-import { cameraToCartographicDegrees } from "../utils/cesiumHelpers";
+import { type Viewer } from "cesium";
 
 import {
   selectShowSecondaryTileset,
@@ -9,15 +8,15 @@ import {
   selectViewerIsTransitioning,
 } from "../slices/cesium";
 
-import { encodeCesiumCamera } from "../..";
 import { useCesiumContext } from "./useCesiumContext";
-import { Viewer } from "cesium";
-import { StringifiedCameraState } from "../utils/cesiumHashParamsCodec";
 
-export const VIEWERSTATE_KEYS = {
-  mapStyle: "m",
-  is3d: "is3d",
-};
+import { cameraToCartographicDegrees } from "../utils/cesiumHelpers";
+import {
+  encodeCesiumCamera,
+  type StringifiedCameraState,
+} from "../utils/cesiumHashParamsCodec";
+
+import { VIEWERSTATE_KEYS } from "../constants";
 
 const toHashParams = (
   cesiumCameraState: StringifiedCameraState,

--- a/libraries/mapping/engines/cesium/src/lib/utils/cesiumHashParamsCodec.ts
+++ b/libraries/mapping/engines/cesium/src/lib/utils/cesiumHashParamsCodec.ts
@@ -114,11 +114,11 @@ export const encodeCesiumCamera = (camera: Camera): StringifiedCameraState => {
 };
 
 export const decodeCesiumCamera = (
-  hashParams: URLSearchParams
+  hashParams: Record<string, string>
 ): CameraState | null => {
   const decoded = Object.keys(cameraCodec).reduce((acc, key) => {
     const shortKey = cameraCodec[key].key;
-    const value = hashParams.get(shortKey);
+    const value = hashParams[shortKey];
     acc[key] =
       value !== null && value !== undefined
         ? cameraCodec[key].decode(value)

--- a/libraries/mapping/engines/cesium/src/lib/utils/cesiumHashParamsCodec.ts
+++ b/libraries/mapping/engines/cesium/src/lib/utils/cesiumHashParamsCodec.ts
@@ -4,6 +4,7 @@ import {
   Math as CesiumMath,
   PerspectiveFrustum,
 } from "cesium";
+import { VIEWERSTATE_KEYS } from "../constants";
 
 // Constants for URL parameter formatting
 const DEGREE_DIGITS = 7;
@@ -69,24 +70,15 @@ const cameraCodec: Record<string, HashCodec> = {
   },
 };
 
-export const cesiumCameraParamsKeyList = Object.values(cameraCodec).map(
+export const cesiumCameraParamKeys = Object.values(cameraCodec).map(
   (codec) => codec.key
 );
 
-export const getClearCesiumCameraParams = (emptyValue = "") => {
-  const only3d = cesiumCameraParamsKeyList.filter(
-    (k) => !["lng", "lat"].includes(k) // keep lng and lat for consistency
-  );
-
-  const clearValues = only3d.reduce(
-    (acc, key) => {
-      acc[key] = emptyValue;
-      return acc;
-    },
-    { is3d: emptyValue }
-  );
-  return clearValues;
-};
+export const cesiumClearParamKeys = cesiumCameraParamKeys
+  .filter(
+    (k) => !["lng", "lat"].includes(k) // keep lng and lat  as they are used for 2D mode too an will be overwritten
+  )
+  .concat(VIEWERSTATE_KEYS.is3d); // remove Cesium Only state keys
 
 function isNumber(value: unknown): value is number {
   return (

--- a/playgrounds/carmamap/src/app/components/CarmaMap/CarmaMap.tsx
+++ b/playgrounds/carmamap/src/app/components/CarmaMap/CarmaMap.tsx
@@ -576,7 +576,12 @@ export const CarmaMap = ({
                     "[GEOPORTALMAP|HASH|SCENE|CESIUM]cesium scene changed",
                     e
                   );
-                  replaceHashRoutedHistory(e, "/");
+                  replaceHashRoutedHistory(
+                    e.hashParams,
+                    "/",
+                    ["zoom"],
+                    "app/carma:3D"
+                  );
                 }}
               ></CustomViewer>
             </div>

--- a/playgrounds/carmamap/src/app/components/CarmaMap/CarmaMap.tsx
+++ b/playgrounds/carmamap/src/app/components/CarmaMap/CarmaMap.tsx
@@ -40,7 +40,6 @@ import { TopicMapContext } from "react-cismap/contexts/TopicMapContextProvider";
 
 import { ENDPOINT, isAreaType } from "@carma-commons/resources";
 import {
-  replaceHashRoutedHistory,
   SelectionMetaData,
   TopicMapSelectionContent,
   useGazData,
@@ -56,6 +55,7 @@ import {
 import {
   detectWebGLContext,
   getApplicationVersion,
+  updateHashHistoryState,
 } from "@carma-commons/utils";
 
 import {
@@ -576,7 +576,7 @@ export const CarmaMap = ({
                     "[GEOPORTALMAP|HASH|SCENE|CESIUM]cesium scene changed",
                     e
                   );
-                  replaceHashRoutedHistory(
+                  updateHashHistoryState(
                     e.hashParams,
                     "/",
                     ["zoom"],

--- a/playgrounds/cesium/src/app/views/tests/standalone/HQ500.tsx
+++ b/playgrounds/cesium/src/app/views/tests/standalone/HQ500.tsx
@@ -168,7 +168,12 @@ export const HQ500 = () => {
                 "[GEOPORTALMAP|HASH|SCENE|CESIUM]cesium scene changed",
                 e
               );
-              replaceHashRoutedHistory(e, location.pathname);
+              replaceHashRoutedHistory(
+                e.hashParams,
+                location.pathname,
+                ["zoom"],
+                "app/hq500:3D"
+              );
             }}
           ></CustomViewer>
         </div>

--- a/playgrounds/cesium/src/app/views/tests/standalone/HQ500.tsx
+++ b/playgrounds/cesium/src/app/views/tests/standalone/HQ500.tsx
@@ -16,7 +16,6 @@ import {
   faPlus,
 } from "@fortawesome/free-solid-svg-icons";
 
-import { replaceHashRoutedHistory } from "@carma-apps/portals";
 import {
   CustomViewer,
   Compass,
@@ -25,6 +24,7 @@ import {
   useZoomControls as useZoomControlsCesium,
 } from "@carma-mapping/cesium-engine";
 import { useTweakpaneCtx } from "@carma-commons/debug";
+import { updateHashHistoryState } from "@carma-commons/utils";
 
 import "cesium/Build/Cesium/Widgets/widgets.css";
 
@@ -168,7 +168,7 @@ export const HQ500 = () => {
                 "[GEOPORTALMAP|HASH|SCENE|CESIUM]cesium scene changed",
                 e
               );
-              replaceHashRoutedHistory(
+              updateHashHistoryState(
                 e.hashParams,
                 location.pathname,
                 ["zoom"],


### PR DESCRIPTION
keeps hash params state update in sync when pushing directly to history.

window.location and window.history state don't contain the same after updating history, so this needs to be tracked by our own state.