### PR TITLE
Feature/routing history

### DIFF
--- a/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
+++ b/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
@@ -407,7 +407,6 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
     updateHash(e.hashParams, {
       clearKeys: ["zoom"],
       label: "GPM:3D",
-      replace: true,
     });
   };
 

--- a/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
+++ b/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
@@ -1,13 +1,6 @@
 import L from "leaflet";
 import proj4 from "proj4";
-import {
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useCallback,
-} from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { TopicMapContext } from "react-cismap/contexts/TopicMapContextProvider";
@@ -21,7 +14,8 @@ import {
   useAuth,
   useFeatureFlags,
   useGazData,
-  useHashState,
+  useMapHashRouting,
+  createLocationChangeHandler,
   useSelectionCesium,
   useSelectionTopicMap,
   useCesiumModels,
@@ -44,7 +38,6 @@ import {
 import { getApplicationVersion } from "@carma-commons/utils";
 
 import {
-  cesiumClearParamKeys,
   CustomViewer,
   selectShowPrimaryTileset,
   selectViewerIsMode2d,
@@ -101,7 +94,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faArrowRightFromBracket,
   faKey,
-  faUser,
 } from "@fortawesome/free-solid-svg-icons";
 
 interface MapProps {
@@ -116,7 +108,6 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
   // Contexts
   const { viewerRef, terrainProviderRef, surfaceProviderRef } =
     useCesiumContext();
-  const { updateHash } = useHashState();
 
   const rerenderCountRef = useRef(0);
   const lastRenderTimeStampRef = useRef(Date.now());
@@ -216,35 +207,18 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
     }
   }, [isMode2d, selectedFeature, dispatch]);
 
-  // On 3D→2D switch: clear 3D hash keys (replace), then push current 2D map position
-  const sync2DUrlOnModeSwitch = useCallback(() => {
-    const map = routedMap?.leafletMap?.leafletElement;
-    // Always clear 3D keys by replacing current entry
-    updateHash(undefined, {
-      clearKeys: cesiumClearParamKeys,
-      label: "GPM:2D:clear3d",
-      replace: true,
+  const { handleTopicMapLocationChange, handleCesiumSceneChange } =
+    useMapHashRouting({
+      isMode2d,
+      getLeafletMap: () => routedMap?.leafletMap?.leafletElement,
+      getLeafletZoom,
+      labels: {
+        clear3d: "GPM:2D:clear3d",
+        write2d: "GPM:2D:writeLocation",
+        topicMapLocation: "GPM:TopicMap:locationChangedHandler",
+        cesiumScene: "GPM:3D",
+      },
     });
-
-    // Then push the current 2D location, if available
-    if (map) {
-      const center = map.getCenter();
-      const zoom = getLeafletZoom();
-      updateHash(
-        { lat: center.lat, lng: center.lng, zoom },
-        { label: "GPM:2D:writeLocation" }
-      );
-    }
-  }, [routedMap, getLeafletZoom, updateHash]);
-
-  const prevIsMode2dRef = useRef<boolean>(isMode2d);
-  useEffect(() => {
-    const was2d = prevIsMode2dRef.current;
-    if (!was2d && isMode2d) {
-      sync2DUrlOnModeSwitch();
-    }
-    prevIsMode2dRef.current = isMode2d;
-  }, [isMode2d, sync2DUrlOnModeSwitch]);
 
   const { gazData } = useGazData();
 
@@ -359,7 +333,13 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
       setPos(null);
       dispatch(setPreferredLayerId(""));
     }
-  }, [uiMode]);
+  }, [
+    uiMode,
+    marker,
+    markerAccent,
+    dispatch,
+    routedMap?.leafletMap?.leafletElement,
+  ]);
 
   useEffect(() => {
     if (isModeFeatureInfo && pos) updateFeatureInfoLeaflet();
@@ -409,30 +389,19 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shouldUpdateFeatureInfo]);
 
-  const topicMapLocationChangedHandler = ({
-    lat,
-    lng,
-    zoom,
-  }: {
-    lat: number;
-    lng: number;
-    zoom: number;
-  }) => {
-    if (!isMode2d) {
-      console.debug(
-        "[TopicMap|DEBUG] Location changed handler triggered while in 3D mode"
-      );
-      return;
-    }
-    updateHash(
-      { lat, lng, zoom },
-      {
-        clearKeys: cesiumClearParamKeys,
-        label: "GPM:TopicMap:locationChangedHandler",
-      }
-    );
-    dispatch(setLayersIdle(false));
-  };
+  const topicMapLocationChangedHandler = useMemo(
+    () =>
+      createLocationChangeHandler({
+        isMode2d,
+        onChange: handleTopicMapLocationChange,
+        onAfter: () => dispatch(setLayersIdle(false)),
+        onMismatch: () =>
+          console.debug(
+            "[TopicMap|DEBUG] Location changed handler triggered while in 3D mode"
+          ),
+      }),
+    [isMode2d, handleTopicMapLocationChange, dispatch]
+  );
 
   const onSceneChange = (e: { hashParams: Record<string, string> }) => {
     if (isMode2d) {
@@ -441,11 +410,7 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
       );
       return;
     }
-    updateHash(e.hashParams, {
-      clearKeys: ["zoom"],
-      label: "GPM:3D",
-      replace: true,
-    });
+    handleCesiumSceneChange(e);
   };
 
   // TODO Move out Controls to own component
@@ -516,8 +481,8 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
           leafletMapProps={{ editable: true }}
           minZoom={10}
           backgroundlayers="empty"
-          mappingBoundsChanged={(boundingbox) => {
-            // console.debug('xxx bbox', createWMSBbox(boundingbox));
+          mappingBoundsChanged={(bbox: unknown) => {
+            console.debug("[TopicMap] bbox changed", bbox);
           }}
           locationChangedHandler={topicMapLocationChangedHandler}
           outerLocationChangedHandlerExclusive={true}
@@ -652,7 +617,6 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
           {createCismapLayers(layers, {
             mode: uiMode,
             dispatch,
-            zoom: getLeafletZoom(),
             selectedFeature,
             leafletMap: routedMap?.leafletMap?.leafletElement,
           })}

--- a/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
+++ b/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
@@ -404,7 +404,11 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
       );
       return;
     }
-    updateHash(e.hashParams, { clearKeys: ["zoom"], label: "GPM:3D" });
+    updateHash(e.hashParams, {
+      clearKeys: ["zoom"],
+      label: "GPM:3D",
+      replace: true,
+    });
   };
 
   // TODO Move out Controls to own component

--- a/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
+++ b/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
@@ -1,6 +1,13 @@
 import L from "leaflet";
 import proj4 from "proj4";
-import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useCallback,
+} from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { TopicMapContext } from "react-cismap/contexts/TopicMapContextProvider";
@@ -209,6 +216,36 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
     }
   }, [isMode2d, selectedFeature, dispatch]);
 
+  // On 3D→2D switch: clear 3D hash keys (replace), then push current 2D map position
+  const sync2DUrlOnModeSwitch = useCallback(() => {
+    const map = routedMap?.leafletMap?.leafletElement;
+    // Always clear 3D keys by replacing current entry
+    updateHash(undefined, {
+      clearKeys: cesiumClearParamKeys,
+      label: "GPM:2D:clear3d",
+      replace: true,
+    });
+
+    // Then push the current 2D location, if available
+    if (map) {
+      const center = map.getCenter();
+      const zoom = getLeafletZoom();
+      updateHash(
+        { lat: center.lat, lng: center.lng, zoom },
+        { label: "GPM:2D:writeLocation" }
+      );
+    }
+  }, [routedMap, getLeafletZoom, updateHash]);
+
+  const prevIsMode2dRef = useRef<boolean>(isMode2d);
+  useEffect(() => {
+    const was2d = prevIsMode2dRef.current;
+    if (!was2d && isMode2d) {
+      sync2DUrlOnModeSwitch();
+    }
+    prevIsMode2dRef.current = isMode2d;
+  }, [isMode2d, sync2DUrlOnModeSwitch]);
+
   const { gazData } = useGazData();
 
   useFeatureInfoModeCursorStyle();
@@ -407,6 +444,7 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
     updateHash(e.hashParams, {
       clearKeys: ["zoom"],
       label: "GPM:3D",
+      replace: true,
     });
   };
 

--- a/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
+++ b/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
@@ -333,13 +333,7 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
       setPos(null);
       dispatch(setPreferredLayerId(""));
     }
-  }, [
-    uiMode,
-    marker,
-    markerAccent,
-    dispatch,
-    routedMap?.leafletMap?.leafletElement,
-  ]);
+  }, [uiMode]);
 
   useEffect(() => {
     if (isModeFeatureInfo && pos) updateFeatureInfoLeaflet();
@@ -481,8 +475,8 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
           leafletMapProps={{ editable: true }}
           minZoom={10}
           backgroundlayers="empty"
-          mappingBoundsChanged={(bbox: unknown) => {
-            console.debug("[TopicMap] bbox changed", bbox);
+          mappingBoundsChanged={(boundingbox) => {
+            // intentionally no-op
           }}
           locationChangedHandler={topicMapLocationChangedHandler}
           outerLocationChangedHandlerExclusive={true}
@@ -617,6 +611,7 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
           {createCismapLayers(layers, {
             mode: uiMode,
             dispatch,
+            zoom: getLeafletZoom(),
             selectedFeature,
             leafletMap: routedMap?.leafletMap?.leafletElement,
           })}

--- a/apps/geoportal/src/app/components/GeoportalMap/LibreGeoportalMap.tsx
+++ b/apps/geoportal/src/app/components/GeoportalMap/LibreGeoportalMap.tsx
@@ -20,6 +20,7 @@ import {
   LibreMapSelectionContent,
   SelectionItem,
   useHashState,
+  useMapHashRouting,
   useSelectionLibreMap,
 } from "@carma-apps/portals";
 
@@ -42,13 +43,12 @@ import {
   addMarkerToMap,
   changeWmsVisibility,
   createFeature,
-  getParamsMapLibre,
   layersToMapLibreStyle,
   zoom256as512,
+  zoom512as256,
 } from "./libremap.utils";
 import {
   cancelOngoingRequests,
-  getCoordinates,
   onClickTopicMap,
   onSelectionChangedVector,
 } from "./topicmap.utils";
@@ -107,7 +107,7 @@ const LibreGeoportalMap = ({
 }: {
   mapOptions?: LibreGeoportalMapOptions;
 }) => {
-  const { updateHash, getHashValues } = useHashState();
+  const { getHashValues } = useHashState();
   const normalizedMapOptions = useMemo(
     () => normalizeOptions(mapOptions, defaultMapOptions),
     [mapOptions]
@@ -148,6 +148,36 @@ const LibreGeoportalMap = ({
 
   const layers = useSelector(getLayers);
   const backgroundLayer = useSelector(getBackgroundLayer);
+
+  // Centralized hash routing for MapLibre (2D-only in this component)
+  const { handleTopicMapLocationChange } = useMapHashRouting({
+    isMode2d: true,
+    getLeafletMap: () => {
+      const m = map.current;
+      if (!m) return null;
+      return {
+        setView: (center: { lat: number; lng: number }, zoom?: number) => {
+          if (typeof zoom === "number") m.setZoom(zoom256as512(zoom));
+          m.setCenter([center.lng, center.lat]);
+        },
+        panTo: (center: { lat: number; lng: number }) =>
+          m.panTo([center.lng, center.lat]),
+        setZoom: (zoom: number) => m.setZoom(zoom256as512(zoom)),
+        getCenter: () => m.getCenter(),
+        once: (type: string, fn: (...args: unknown[]) => void) =>
+          m.once(type, fn),
+      };
+    },
+    getLeafletZoom: () => {
+      const m = map.current;
+      return m ? zoom512as256(m.getZoom()) : normalizedMapOptions.zoom;
+    },
+    labels: {
+      clear3d: "LGM:2D:clear3d",
+      write2d: "LGM:2D:writeLocation",
+      topicMapLocation: "LGM:2D:location",
+    },
+  });
 
   const onComplete = (
     selection: SelectionItem,
@@ -438,8 +468,6 @@ const LibreGeoportalMap = ({
 
           if (filteredHits.length > 0) {
             const selectedVectorFeature = filteredHits[0];
-
-            const coordinates = getCoordinates(selectedVectorFeature.geometry);
             const layerId = selectedVectorFeature.layer?.metadata?.["layer-id"];
             const currentLayers = getLayers(store.getState());
             const layer = currentLayers.find((layer) => layer.id === layerId);
@@ -504,7 +532,7 @@ const LibreGeoportalMap = ({
 
                 // Update the selection layer filter to show this building
                 if (map.current.getLayer(selectionLayerId)) {
-                  const filterConditions: any[] = [
+                  const filterConditions: unknown[] = [
                     "all",
                     ["==", ["geometry-type"], "Polygon"],
                   ];
@@ -587,22 +615,22 @@ const LibreGeoportalMap = ({
         map.current.remove();
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
     const mapInstance = map.current;
-    if (!mapInstance || typeof updateHash !== "function") return;
+    if (!mapInstance) return;
     const handleMoveEnd = () => {
-      if (!mapInstance) return;
-      updateHash(getParamsMapLibre(mapInstance, defaultMapOptions), {
-        label: "MapLibre",
-      });
+      const center = mapInstance.getCenter();
+      const zoom = zoom512as256(mapInstance.getZoom());
+      handleTopicMapLocationChange({ lat: center.lat, lng: center.lng, zoom });
     };
     mapInstance.on("moveend", handleMoveEnd);
     return () => {
       mapInstance && mapInstance.off("moveend", handleMoveEnd);
     };
-  }, [updateHash]);
+  }, [handleTopicMapLocationChange]);
 
   useEffect(() => {
     if (!map.current) return;

--- a/apps/geoportal/src/app/components/GeoportalMap/controls/MapWrapper.tsx
+++ b/apps/geoportal/src/app/components/GeoportalMap/controls/MapWrapper.tsx
@@ -21,7 +21,6 @@ import {
   SelectionMetaData,
   useFeatureFlags,
   useGazData,
-  useHashState,
   useSelection,
 } from "@carma-apps/portals";
 
@@ -31,7 +30,6 @@ import type { SearchResultItem } from "@carma-commons/types";
 import { detectWebGLContext } from "@carma-commons/utils";
 
 import {
-  cesiumClearParamKeys,
   MapTypeSwitcher,
   PitchingCompass,
   selectViewerIsMode2d,
@@ -197,8 +195,6 @@ const MapWrapper = () => {
   const [zenButtonHidden, setZenButtonHidden] = useState(false);
   const [isHoveringZenButton, setIsHoveringZenButton] = useState(false);
 
-  const { updateHash } = useHashState();
-
   useEffect(() => {
     if (routedMap?.leafletMap) {
       const map = routedMap.leafletMap.leafletElement;
@@ -252,14 +248,6 @@ const MapWrapper = () => {
   const tourRefLabels = useTourRefCollabLabels();
   const { gazData } = useGazData();
   const { width, height } = useWindowSize(wrapperRef);
-
-  const clear3dHashParams = () => {
-    updateHash &&
-      updateHash(undefined, {
-        clearKeys: cesiumClearParamKeys,
-        label: "MapTypeSwitcher Clear",
-      });
-  };
 
   const handleToggleMeasurement = () => {
     cancelOngoingRequests();
@@ -418,10 +406,6 @@ const MapWrapper = () => {
                   // TODO: move Config to props
                   duration={CESIUM_CONFIG.transitions.mapMode.duration}
                   className="!rounded-t-none !border-t-[1px]"
-                  onComplete={(isTo2d: boolean) => {
-                    isTo2d && clear3dHashParams();
-                    //dispatch(setBackgroundLayer({ ...backgroundLayer, visible: isTo2d }));
-                  }}
                   ref={tourRefLabels.toggle2d3d}
                 />
                 {

--- a/apps/geoportal/src/app/components/GeoportalMap/topicmap.utils.ts
+++ b/apps/geoportal/src/app/components/GeoportalMap/topicmap.utils.ts
@@ -595,13 +595,11 @@ export const createCismapLayers = (
   {
     mode,
     dispatch,
-    zoom,
     selectedFeature,
     leafletMap,
   }: {
     mode: UIMode;
     dispatch: Dispatch;
-    zoom: number;
     selectedFeature: any;
     leafletMap: Map;
   }

--- a/apps/geoportal/src/app/components/GeoportalMap/topicmap.utils.ts
+++ b/apps/geoportal/src/app/components/GeoportalMap/topicmap.utils.ts
@@ -595,11 +595,13 @@ export const createCismapLayers = (
   {
     mode,
     dispatch,
+    zoom,
     selectedFeature,
     leafletMap,
   }: {
     mode: UIMode;
     dispatch: Dispatch;
+    zoom: number;
     selectedFeature: any;
     leafletMap: Map;
   }

--- a/apps/geoportal/src/app/hooks/useAppConfig.ts
+++ b/apps/geoportal/src/app/hooks/useAppConfig.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import {
   type LayerMap,
@@ -80,6 +80,7 @@ export const useAppConfig = (
 ) => {
   const dispatch = useDispatch();
   const { pathname } = useLocation();
+  const navigate = useNavigate();
   const [isLoadingConfig, setIsLoadingConfig] = useState<boolean | null>(null); // initially null to indicate undetermined state
 
   useEffect(() => {
@@ -92,6 +93,8 @@ export const useAppConfig = (
     }
     updateHashHistoryState({ [configKey]: undefined }, pathname, {
       label: "remove config search parameter",
+      navigate,
+      replace: true,
     });
 
     if (config === null || config === "") {

--- a/apps/geoportal/src/app/hooks/useAppConfig.ts
+++ b/apps/geoportal/src/app/hooks/useAppConfig.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 import {
   type LayerMap,
@@ -80,7 +80,6 @@ export const useAppConfig = (
 ) => {
   const dispatch = useDispatch();
   const { pathname } = useLocation();
-  const navigate = useNavigate();
   const [isLoadingConfig, setIsLoadingConfig] = useState<boolean | null>(null); // initially null to indicate undetermined state
 
   useEffect(() => {
@@ -91,9 +90,12 @@ export const useAppConfig = (
       console.info("[CONFIG] No config key provided in hash parameters.");
       return;
     }
+    // can't use HashStateProvider here
+    // because it's not yet available
+    // and needs to be configured by the config itself
+    // use direct history state update instead
     updateHashHistoryState({ [configKey]: undefined }, pathname, {
       label: "remove config search parameter",
-      navigate,
       replace: true,
     });
 

--- a/envirometrics/wuppertal/floodingmap/src/App.tsx
+++ b/envirometrics/wuppertal/floodingmap/src/App.tsx
@@ -23,16 +23,10 @@ import {
   useSelection,
   useSelectionCesium,
   useSelectionTopicMap,
+  useHashState,
 } from "@carma-apps/portals";
-import {
-  ENDPOINT,
-  isAreaType,
-  isAreaTypeWithGEP,
-} from "@carma-commons/resources";
-import {
-  getApplicationVersion,
-  updateHashHistoryState,
-} from "@carma-commons/utils";
+import { ENDPOINT, isAreaTypeWithGEP } from "@carma-commons/resources";
+import { getApplicationVersion } from "@carma-commons/utils";
 
 import { getCollabedHelpComponentConfig } from "@carma-collab/wuppertal/hochwassergefahrenkarte";
 
@@ -93,6 +87,7 @@ function App({ sync = false }: { sync?: boolean }) {
     responsiveState === "normal" ? "300px" : windowSize.width - gap - 2;
 
   const { gazData } = useGazData();
+  const { updateHash } = useHashState();
 
   const reactCismapEnvirometricsVersion = cismapEnvirometricsVersion;
   const [hochwasserschutz, setHochwasserschutz] = useState(true);
@@ -172,13 +167,13 @@ function App({ sync = false }: { sync?: boolean }) {
   };
 
   const onCesiumSceneChange = (e) => {
-    isMode2d
-      ? undefined
-      : updateHashHistoryState(e.hashParams, "/", {
-          removeKeys: ["zoom"],
-          label: "app/hgk:3D",
-          replace: true,
-        });
+    if (!isMode2d) {
+      updateHash(e.hashParams, {
+        clearKeys: ["zoom"],
+        label: "app/hgk:3D",
+        replace: true,
+      });
+    }
   };
 
   useSelectionTopicMap();
@@ -212,19 +207,15 @@ function App({ sync = false }: { sync?: boolean }) {
       !viewerRef.current.isDestroyed()
     ) {
       const viewer = viewerRef.current;
-      // remove default cesium credit because no ion resource is used;
-      (viewer as any)._cesiumWidget._creditContainer.style.display = "none";
+      // remove default cesium credit because no ion resource is used
+      (
+        viewer as unknown as {
+          _cesiumWidget: { _creditContainer: { style: { display: string } } };
+        }
+      )._cesiumWidget._creditContainer.style.display = "none";
       viewer.scene.requestRender();
     }
   }, [viewerRef, isViewerReady]);
-
-  const onFullscreenClick = () => {
-    if (document.fullscreenElement) {
-      document.exitFullscreen();
-    } else {
-      document.documentElement.requestFullscreen();
-    }
-  };
 
   const enableControlStateToggle = (controlState) => {
     return controlState.selectedSimulation !== 2;

--- a/envirometrics/wuppertal/floodingmap/src/App.tsx
+++ b/envirometrics/wuppertal/floodingmap/src/App.tsx
@@ -177,6 +177,7 @@ function App({ sync = false }: { sync?: boolean }) {
       : updateHashHistoryState(e.hashParams, "/", {
           removeKeys: ["zoom"],
           label: "app/hgk:3D",
+          replace: true,
         });
   };
 

--- a/envirometrics/wuppertal/floodingmap/src/main.tsx
+++ b/envirometrics/wuppertal/floodingmap/src/main.tsx
@@ -5,11 +5,14 @@ import { Provider } from "react-redux";
 import { persistStore } from "redux-persist";
 import { PersistGate } from "redux-persist/integration/react";
 
-import { MappingConstants } from "react-cismap";
 import { TopicMapContextProvider } from "react-cismap/contexts/TopicMapContextProvider";
 import { CrossTabCommunicationContextProvider } from "react-cismap/contexts/CrossTabCommunicationContextProvider";
 
-import { GazDataProvider, SelectionProvider } from "@carma-apps/portals";
+import {
+  GazDataProvider,
+  SelectionProvider,
+  HashStateProvider,
+} from "@carma-apps/portals";
 import { TweakpaneProvider } from "@carma-commons/debug";
 import { suppressReactCismapErrors } from "@carma-commons/utils";
 import {
@@ -46,12 +49,14 @@ const appWithContext = (
         // baseLayerConf={wuppertalConfig.overridingBaseLayerConf}
         infoBoxPixelWidth={370}
       >
-        <CesiumContextProvider
-          providerConfig={CESIUM_CONFIG.providerConfig}
-          tilesetConfigs={CESIUM_CONFIG.tilesetConfigs}
-        >
-          {enableSync ? syncedApp : <App />}
-        </CesiumContextProvider>
+        <HashStateProvider>
+          <CesiumContextProvider
+            providerConfig={CESIUM_CONFIG.providerConfig}
+            tilesetConfigs={CESIUM_CONFIG.tilesetConfigs}
+          >
+            {enableSync ? syncedApp : <App />}
+          </CesiumContextProvider>
+        </HashStateProvider>
       </TopicMapContextProvider>
     </SelectionProvider>
   </GazDataProvider>

--- a/libraries/appframeworks/portals/src/index.ts
+++ b/libraries/appframeworks/portals/src/index.ts
@@ -32,6 +32,9 @@ export { useAuth } from "./lib/components/AuthProvider";
 export {
   HashStateProvider,
   useHashState,
+  type HashChangeEvent,
+  type HashChangeSource,
+  type HashSubscribeOptions,
 } from "./lib/contexts/HashStateProvider";
 export {
   MapStyleProvider,
@@ -59,6 +62,11 @@ export { useShareUrl, SHORTENER_URL } from "./lib/hooks/useShareUrl";
 export { useProgress } from "./lib/hooks/useProgress";
 export { useCesiumModels } from "./lib/hooks/useCesiumModels";
 export { useCesiumModelSelection } from "./lib/hooks/useCesiumModelSelection";
+export {
+  useMapHashRouting,
+  createLocationChangeHandler,
+  type LatLngZoom,
+} from "./lib/hooks/useMapHashRouting";
 export { uploadImage } from "./lib/utils/fileUpload";
 export {
   defaultBackgroundConfigurations,

--- a/libraries/appframeworks/portals/src/lib/contexts/HashStateProvider.tsx
+++ b/libraries/appframeworks/portals/src/lib/contexts/HashStateProvider.tsx
@@ -15,6 +15,8 @@ import { useLocation } from "react-router-dom";
 interface HashUpdateOptions {
   clearKeys?: string[];
   label?: string;
+  // If true, do not add a new history entry; replace current one instead
+  replace?: boolean;
 }
 export type HashCodec<T = unknown> = {
   name?: string;
@@ -28,6 +30,7 @@ export type HashKeyAliases = Record<string, string>;
 const hashUpdateDefaults: Required<HashUpdateOptions> = {
   clearKeys: [],
   label: "unspecified",
+  replace: false,
 };
 
 interface HashStateContextType {
@@ -84,7 +87,7 @@ export const HashStateProvider: React.FC<{
       params: Record<string, unknown> | undefined,
       options?: HashUpdateOptions
     ) => {
-      const { clearKeys, label } = normalizeOptions(
+      const { clearKeys, label, replace } = normalizeOptions(
         options,
         hashUpdateDefaults
       );
@@ -115,6 +118,7 @@ export const HashStateProvider: React.FC<{
         removeKeys: clearAndUndefinedKeys,
         keyOrder,
         label: label || "unspecified",
+        replace,
       });
     },
     [location.pathname, keyAliases, hashCodecs, keyOrder]

--- a/libraries/appframeworks/portals/src/lib/contexts/HashStateProvider.tsx
+++ b/libraries/appframeworks/portals/src/lib/contexts/HashStateProvider.tsx
@@ -10,8 +10,10 @@ import {
   getHashParams,
   normalizeOptions,
   updateHashHistoryState,
+  diffHashParams,
 } from "@carma-commons/utils";
 import { useLocation, useNavigate } from "react-router-dom";
+import { useHashChangeEmit } from "../hooks/useHashChangeEmit";
 
 interface HashUpdateOptions {
   clearKeys?: string[];
@@ -174,18 +176,8 @@ export const HashStateProvider: React.FC<{
       });
 
       const afterRaw = getHashParams();
-      const allKeys = new Set<string>([
-        ...Object.keys(beforeRaw),
-        ...Object.keys(afterRaw),
-      ]);
-      const changedAliasKeys: string[] = [];
-      const removedAliasKeys: string[] = [];
-      allKeys.forEach((k) => {
-        if (beforeRaw[k] !== afterRaw[k]) changedAliasKeys.push(k);
-      });
-      Object.keys(beforeRaw).forEach((k) => {
-        if (!(k in afterRaw)) removedAliasKeys.push(k);
-      });
+      const { changedKeys: changedAliasKeys, removedKeys: removedAliasKeys } =
+        diffHashParams(beforeRaw, afterRaw);
       const toOriginal = (k: string) => aliasReverseLookup[k] || k;
       const changedKeys = [...new Set(changedAliasKeys.map(toOriginal))];
       const removedKeys = [...new Set(removedAliasKeys.map(toOriginal))];
@@ -212,43 +204,12 @@ export const HashStateProvider: React.FC<{
     ]
   );
 
-  useEffect(() => {
-    const handle = (source: HashChangeSource) => () => {
-      const beforeRaw = prevRawRef.current || {};
-      const afterRaw = getHashParams();
-      const allKeys = new Set<string>([
-        ...Object.keys(beforeRaw),
-        ...Object.keys(afterRaw),
-      ]);
-      const changedAliasKeys: string[] = [];
-      const removedAliasKeys: string[] = [];
-      allKeys.forEach((k) => {
-        if (beforeRaw[k] !== afterRaw[k]) changedAliasKeys.push(k);
-      });
-      Object.keys(beforeRaw).forEach((k) => {
-        if (!(k in afterRaw)) removedAliasKeys.push(k);
-      });
-      const toOriginal = (k: string) => aliasReverseLookup[k] || k;
-      const changedKeys = [...new Set(changedAliasKeys.map(toOriginal))];
-      const removedKeys = [...new Set(removedAliasKeys.map(toOriginal))];
-      emit({
-        raw: afterRaw,
-        values: getHashValues(),
-        changedKeys,
-        removedKeys,
-        source,
-      });
-      prevRawRef.current = afterRaw;
-    };
-    const onPop = handle("popstate");
-    const onHash = handle("hashchange");
-    window.addEventListener("popstate", onPop);
-    window.addEventListener("hashchange", onHash);
-    return () => {
-      window.removeEventListener("popstate", onPop);
-      window.removeEventListener("hashchange", onHash);
-    };
-  }, [emit, getHashValues, aliasReverseLookup]);
+  useHashChangeEmit({
+    emit: (e) => emit(e as any),
+    getHashValues,
+    aliasReverseLookup,
+    prevRawRef,
+  });
 
   const value = useRef<HashStateContextType>({
     getHash,

--- a/libraries/appframeworks/portals/src/lib/contexts/HashStateProvider.tsx
+++ b/libraries/appframeworks/portals/src/lib/contexts/HashStateProvider.tsx
@@ -11,7 +11,7 @@ import {
   normalizeOptions,
   updateHashHistoryState,
 } from "@carma-commons/utils";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 interface HashUpdateOptions {
   clearKeys?: string[];
@@ -81,6 +81,7 @@ export const HashStateProvider: React.FC<{
   keyOrder?: string[];
 }> = ({ children, keyAliases, hashCodecs, keyOrder }) => {
   const location = useLocation();
+  const navigate = useNavigate();
   const aliasReverseLookup = useMemo(
     () => getAliasReverseLookup(keyAliases || {}),
     [keyAliases]
@@ -169,6 +170,7 @@ export const HashStateProvider: React.FC<{
         keyOrder,
         label: label || "unspecified",
         replace,
+        navigate,
       });
 
       const afterRaw = getHashParams();

--- a/libraries/appframeworks/portals/src/lib/contexts/HashStateProvider.tsx
+++ b/libraries/appframeworks/portals/src/lib/contexts/HashStateProvider.tsx
@@ -2,6 +2,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
 } from "react";
@@ -33,6 +34,21 @@ const hashUpdateDefaults: Required<HashUpdateOptions> = {
   replace: false,
 };
 
+export type HashChangeSource = "update" | "popstate" | "hashchange";
+export type HashChangeEvent = {
+  raw: Record<string, string>;
+  values: Record<string, unknown>;
+  changedKeys: string[];
+  removedKeys: string[];
+  label?: string;
+  replace?: boolean;
+  source: HashChangeSource;
+};
+export type HashSubscribeOptions = {
+  keys?: string[];
+  labels?: string[];
+};
+
 interface HashStateContextType {
   getHash: () => Record<string, string>;
   getHashValues: () => Record<string, unknown>;
@@ -40,6 +56,10 @@ interface HashStateContextType {
     params: Record<string, unknown> | undefined,
     options?: HashUpdateOptions
   ) => void;
+  subscribe: (
+    listener: (e: HashChangeEvent) => void,
+    opts?: HashSubscribeOptions
+  ) => () => void;
 }
 
 const HashStateContext = createContext<HashStateContextType | undefined>(
@@ -65,6 +85,10 @@ export const HashStateProvider: React.FC<{
     () => getAliasReverseLookup(keyAliases || {}),
     [keyAliases]
   );
+  const listenersRef = useRef<
+    Set<{ listener: (e: HashChangeEvent) => void; opts?: HashSubscribeOptions }>
+  >(new Set());
+  const prevRawRef = useRef<Record<string, string>>(getHashParams());
   // returns the current hash parameters as an object as is with aliased keys
   const getHash = useCallback(() => getHashParams(), []);
   // return the decoded hash values with their original keys, not aliases
@@ -82,11 +106,37 @@ export const HashStateProvider: React.FC<{
     return values;
   }, [hashCodecs, aliasReverseLookup]);
 
+  const emit = useCallback((e: HashChangeEvent) => {
+    listenersRef.current.forEach(({ listener, opts }) => {
+      const keyFilterOk =
+        !opts?.keys ||
+        opts.keys.some((k) =>
+          new Set([...e.changedKeys, ...e.removedKeys]).has(k)
+        );
+      const labelFilterOk =
+        !opts?.labels ||
+        (e.label !== undefined && opts.labels.includes(e.label));
+      if (keyFilterOk && labelFilterOk) listener(e);
+    });
+  }, []);
+
+  const subscribe = useCallback<HashStateContextType["subscribe"]>(
+    (listener, opts) => {
+      const entry = { listener, opts };
+      listenersRef.current.add(entry);
+      return () => {
+        listenersRef.current.delete(entry);
+      };
+    },
+    []
+  );
+
   const updateHash = useCallback(
     (
       params: Record<string, unknown> | undefined,
       options?: HashUpdateOptions
     ) => {
+      const beforeRaw = getHashParams();
       const { clearKeys, label, replace } = normalizeOptions(
         options,
         hashUpdateDefaults
@@ -120,18 +170,94 @@ export const HashStateProvider: React.FC<{
         label: label || "unspecified",
         replace,
       });
+
+      const afterRaw = getHashParams();
+      const allKeys = new Set<string>([
+        ...Object.keys(beforeRaw),
+        ...Object.keys(afterRaw),
+      ]);
+      const changedAliasKeys: string[] = [];
+      const removedAliasKeys: string[] = [];
+      allKeys.forEach((k) => {
+        if (beforeRaw[k] !== afterRaw[k]) changedAliasKeys.push(k);
+      });
+      Object.keys(beforeRaw).forEach((k) => {
+        if (!(k in afterRaw)) removedAliasKeys.push(k);
+      });
+      const toOriginal = (k: string) => aliasReverseLookup[k] || k;
+      const changedKeys = [...new Set(changedAliasKeys.map(toOriginal))];
+      const removedKeys = [...new Set(removedAliasKeys.map(toOriginal))];
+
+      emit({
+        raw: afterRaw,
+        values: getHashValues(),
+        changedKeys,
+        removedKeys,
+        label,
+        replace,
+        source: "update",
+      });
+      prevRawRef.current = afterRaw;
     },
-    [location.pathname, keyAliases, hashCodecs, keyOrder]
+    [
+      location.pathname,
+      keyAliases,
+      hashCodecs,
+      keyOrder,
+      emit,
+      getHashValues,
+      aliasReverseLookup,
+    ]
   );
+
+  useEffect(() => {
+    const handle = (source: HashChangeSource) => () => {
+      const beforeRaw = prevRawRef.current || {};
+      const afterRaw = getHashParams();
+      const allKeys = new Set<string>([
+        ...Object.keys(beforeRaw),
+        ...Object.keys(afterRaw),
+      ]);
+      const changedAliasKeys: string[] = [];
+      const removedAliasKeys: string[] = [];
+      allKeys.forEach((k) => {
+        if (beforeRaw[k] !== afterRaw[k]) changedAliasKeys.push(k);
+      });
+      Object.keys(beforeRaw).forEach((k) => {
+        if (!(k in afterRaw)) removedAliasKeys.push(k);
+      });
+      const toOriginal = (k: string) => aliasReverseLookup[k] || k;
+      const changedKeys = [...new Set(changedAliasKeys.map(toOriginal))];
+      const removedKeys = [...new Set(removedAliasKeys.map(toOriginal))];
+      emit({
+        raw: afterRaw,
+        values: getHashValues(),
+        changedKeys,
+        removedKeys,
+        source,
+      });
+      prevRawRef.current = afterRaw;
+    };
+    const onPop = handle("popstate");
+    const onHash = handle("hashchange");
+    window.addEventListener("popstate", onPop);
+    window.addEventListener("hashchange", onHash);
+    return () => {
+      window.removeEventListener("popstate", onPop);
+      window.removeEventListener("hashchange", onHash);
+    };
+  }, [emit, getHashValues, aliasReverseLookup]);
 
   const value = useRef<HashStateContextType>({
     getHash,
     getHashValues,
     updateHash,
+    subscribe,
   });
   value.current.getHash = getHash;
   value.current.getHashValues = getHashValues;
   value.current.updateHash = updateHash;
+  value.current.subscribe = subscribe;
 
   return (
     <HashStateContext.Provider value={value.current}>

--- a/libraries/appframeworks/portals/src/lib/hooks/useHashChangeEmit.ts
+++ b/libraries/appframeworks/portals/src/lib/hooks/useHashChangeEmit.ts
@@ -1,0 +1,48 @@
+import { useEffect, type MutableRefObject } from "react";
+import { getHashParams, diffHashParams } from "@carma-commons/utils";
+
+type Emitter = (e: {
+  raw: Record<string, string>;
+  values: Record<string, unknown>;
+  changedKeys: string[];
+  removedKeys: string[];
+  source: "popstate" | "hashchange";
+}) => void;
+
+export function useHashChangeEmit(args: {
+  emit: Emitter;
+  getHashValues: () => Record<string, unknown>;
+  aliasReverseLookup: Record<string, string>;
+  prevRawRef: MutableRefObject<Record<string, string>>;
+}) {
+  const { emit, getHashValues, aliasReverseLookup, prevRawRef } = args;
+
+  useEffect(() => {
+    const handle = (source: "popstate" | "hashchange") => () => {
+      const beforeRaw = prevRawRef.current || {};
+      const afterRaw = getHashParams();
+      const { changedKeys: changedAliasKeys, removedKeys: removedAliasKeys } =
+        diffHashParams(beforeRaw, afterRaw);
+      const toOriginal = (k: string) => aliasReverseLookup[k] || k;
+      const changedKeys = [...new Set(changedAliasKeys.map(toOriginal))];
+      const removedKeys = [...new Set(removedAliasKeys.map(toOriginal))];
+      emit({
+        raw: afterRaw,
+        values: getHashValues(),
+        changedKeys,
+        removedKeys,
+        source,
+      });
+      prevRawRef.current = afterRaw;
+    };
+
+    const onPop = handle("popstate");
+    const onHash = handle("hashchange");
+    window.addEventListener("popstate", onPop);
+    window.addEventListener("hashchange", onHash);
+    return () => {
+      window.removeEventListener("popstate", onPop);
+      window.removeEventListener("hashchange", onHash);
+    };
+  }, [emit, getHashValues, aliasReverseLookup, prevRawRef]);
+}

--- a/libraries/appframeworks/portals/src/lib/hooks/useMapHashRouting.ts
+++ b/libraries/appframeworks/portals/src/lib/hooks/useMapHashRouting.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useHashState } from "../contexts/HashStateProvider";
+
+import { cesiumClearParamKeys } from "@carma-mapping/cesium-engine";
+
+export type LatLngZoom = { lat: number; lng: number; zoom: number };
+export type CesiumSceneChangeEvent = { hashParams: Record<string, string> };
+
+type Labels = {
+  clear3d?: string;
+  write2d?: string;
+  topicMapLocation?: string;
+  cesiumScene?: string;
+};
+
+type LeafletLikeMap = {
+  setView?: (center: { lat: number; lng: number }, zoom?: number) => void;
+  panTo?: (center: { lat: number; lng: number }) => void;
+  setZoom?: (zoom: number) => void;
+  getCenter?: () => { lat: number; lng: number };
+};
+
+export interface UseMapHashRoutingOptions {
+  isMode2d: boolean;
+  getLeafletMap?: () => LeafletLikeMap | null | undefined;
+  getLeafletZoom?: () => number;
+  cesiumClearKeys?: string[];
+  labels?: Labels;
+}
+
+export function useMapHashRouting({
+  isMode2d,
+  getLeafletMap,
+  getLeafletZoom,
+  cesiumClearKeys = cesiumClearParamKeys,
+  labels,
+}: UseMapHashRoutingOptions) {
+  const { updateHash, subscribe } = useHashState();
+
+  // Prevent write loops when we programmatically move the map due to history navigation
+  const suppressWriteRef = useRef(false);
+
+  const handleTopicMapLocationChange = useCallback(
+    ({ lat, lng, zoom }: LatLngZoom) => {
+      if (!isMode2d) return;
+      if (suppressWriteRef.current) return;
+      updateHash(
+        { lat, lng, zoom },
+        {
+          clearKeys: cesiumClearKeys,
+          label: labels?.topicMapLocation ?? "Map:2D:location",
+        }
+      );
+    },
+    [isMode2d, updateHash, cesiumClearKeys, labels?.topicMapLocation]
+  );
+
+  const handleCesiumSceneChange = useCallback(
+    (e: CesiumSceneChangeEvent) => {
+      if (isMode2d) return;
+      updateHash(e.hashParams, {
+        clearKeys: ["zoom"],
+        label: labels?.cesiumScene ?? "Map:3D:scene",
+        replace: true,
+      });
+    },
+    [isMode2d, updateHash, labels?.cesiumScene]
+  );
+
+  const prevIsMode2dRef = useRef<boolean>(isMode2d);
+  useEffect(() => {
+    const was2d = prevIsMode2dRef.current;
+    if (!was2d && isMode2d) {
+      // Replace current entry to clear 3D-specific state
+      updateHash(undefined, {
+        clearKeys: cesiumClearKeys,
+        label: labels?.clear3d ?? "Map:2D:clear3d",
+        replace: true,
+      });
+      // Then push current 2D location
+      const map = getLeafletMap?.();
+      if (map && getLeafletZoom) {
+        const center = map.getCenter();
+        const zoom = getLeafletZoom();
+        updateHash(
+          { lat: center.lat, lng: center.lng, zoom },
+          { label: labels?.write2d ?? "Map:2D:writeLocation" }
+        );
+      }
+    }
+    prevIsMode2dRef.current = isMode2d;
+  }, [
+    isMode2d,
+    updateHash,
+    getLeafletMap,
+    getLeafletZoom,
+    cesiumClearKeys,
+    labels?.clear3d,
+    labels?.write2d,
+  ]);
+
+  // Back/forward navigation: move the 2D map to the historical location without writing a new hash
+  useEffect(() => {
+    if (!getLeafletMap) return;
+    const unsub = subscribe(
+      (e) => {
+        if (e.source !== "popstate") return;
+        if (!isMode2d) return;
+        const lat = e.values.lat as number | undefined;
+        const lng = e.values.lng as number | undefined;
+        const zoom =
+          (e.values.zoom as number | undefined) ?? getLeafletZoom?.();
+        if (lat == null || lng == null || zoom == null) return;
+        const map = getLeafletMap?.();
+        if (!map) return;
+        suppressWriteRef.current = true;
+        try {
+          if (typeof map.setView === "function") {
+            map.setView({ lat, lng }, zoom);
+          } else if (typeof map.panTo === "function") {
+            map.panTo({ lat, lng });
+            if (typeof map.setZoom === "function") map.setZoom(zoom);
+          }
+        } finally {
+          setTimeout(() => {
+            suppressWriteRef.current = false;
+          }, 50);
+        }
+      },
+      { keys: ["lat", "lng", "zoom"] }
+    );
+    return unsub;
+  }, [subscribe, isMode2d, getLeafletMap, getLeafletZoom]);
+
+  return { handleTopicMapLocationChange, handleCesiumSceneChange };
+}
+
+export function createLocationChangeHandler({
+  isMode2d,
+  onChange,
+  onAfter,
+  onMismatch,
+}: {
+  isMode2d: boolean;
+  onChange: (p: LatLngZoom) => void;
+  onAfter?: () => void;
+  onMismatch?: () => void;
+}) {
+  return (p: LatLngZoom) => {
+    if (!isMode2d) {
+      onMismatch?.();
+      return;
+    }
+    onChange(p);
+    onAfter?.();
+  };
+}

--- a/libraries/appframeworks/portals/src/lib/hooks/useMapHashRouting.ts
+++ b/libraries/appframeworks/portals/src/lib/hooks/useMapHashRouting.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { useHashState } from "../contexts/HashStateProvider";
 
 import { cesiumClearParamKeys } from "@carma-mapping/cesium-engine";
+import { isLocationEqualWithinPixelTolerance } from "@carma-commons/utils";
 
 export type LatLngZoom = { lat: number; lng: number; zoom: number };
 export type CesiumSceneChangeEvent = { hashParams: Record<string, string> };
@@ -27,6 +28,7 @@ export interface UseMapHashRoutingOptions {
   getLeafletZoom?: () => number;
   cesiumClearKeys?: string[];
   labels?: Labels;
+  pixelTolerance?: number; // px
 }
 
 export function useMapHashRouting({
@@ -35,6 +37,7 @@ export function useMapHashRouting({
   getLeafletZoom,
   cesiumClearKeys = cesiumClearParamKeys,
   labels,
+  pixelTolerance,
 }: UseMapHashRoutingOptions) {
   const { updateHash, subscribe, getHashValues } = useHashState();
 
@@ -61,11 +64,12 @@ export function useMapHashRouting({
       // If we just restored to a target via popstate, allow small drift without pushing
       const target = popstateTargetRef.current;
       if (target) {
-        const tol = 3e-5; // ~3 meters
-        const nearLat = Math.abs(lat - target.lat) <= tol;
-        const nearLng = Math.abs(lng - target.lng) <= tol;
-        const sameZoom = Math.abs(zoom - target.zoom) < 1e-6;
-        if (nearLat && nearLng && sameZoom) {
+        if (
+          isLocationEqualWithinPixelTolerance({ lat, lng, zoom }, target, {
+            pixelTolerance,
+            zoomTolerance: 1e-6,
+          })
+        ) {
           console.debug(
             "[Routing][hash] (2D) skip push: equals popstate target within tolerance",
             { lat, lng, zoom, target }
@@ -80,12 +84,19 @@ export function useMapHashRouting({
         const hLat = Number((vals as Record<string, unknown>).lat);
         const hLng = Number((vals as Record<string, unknown>).lng);
         const hZoom = Number((vals as Record<string, unknown>).zoom);
-        const tol = 3e-5; // ~3 meters
-        const sameLat = Number.isFinite(hLat) && Math.abs(lat - hLat) <= tol;
-        const sameLng = Number.isFinite(hLng) && Math.abs(lng - hLng) <= tol;
-        const sameZoom =
-          Number.isFinite(hZoom) && Math.abs(zoom - hZoom) < 1e-6;
-        if (sameLat && sameLng && sameZoom) {
+        const h =
+          Number.isFinite(hLat) &&
+          Number.isFinite(hLng) &&
+          Number.isFinite(hZoom)
+            ? { lat: hLat, lng: hLng, zoom: hZoom }
+            : undefined;
+        if (
+          h &&
+          isLocationEqualWithinPixelTolerance({ lat, lng, zoom }, h, {
+            pixelTolerance,
+            zoomTolerance: 1e-6,
+          })
+        ) {
           console.debug(
             "[Routing][hash] (2D) skip push: equals current hash within tolerance",
             { lat, lng, zoom, hLat, hLng, hZoom }
@@ -108,6 +119,7 @@ export function useMapHashRouting({
       getHashValues,
       cesiumClearKeys,
       labels?.topicMapLocation,
+      pixelTolerance,
     ]
   );
 

--- a/libraries/appframeworks/portals/src/lib/hooks/useMapHashRouting.ts
+++ b/libraries/appframeworks/portals/src/lib/hooks/useMapHashRouting.ts
@@ -79,7 +79,11 @@ export function useMapHashRouting({
       });
       // Then push current 2D location
       const map = getLeafletMap?.();
-      if (map && getLeafletZoom) {
+      if (
+        map &&
+        typeof map.getCenter === "function" &&
+        typeof getLeafletZoom === "function"
+      ) {
         const center = map.getCenter();
         const zoom = getLeafletZoom();
         updateHash(

--- a/libraries/appframeworks/portals/src/lib/hooks/useMapHashRouting.ts
+++ b/libraries/appframeworks/portals/src/lib/hooks/useMapHashRouting.ts
@@ -36,15 +36,63 @@ export function useMapHashRouting({
   cesiumClearKeys = cesiumClearParamKeys,
   labels,
 }: UseMapHashRoutingOptions) {
-  const { updateHash, subscribe } = useHashState();
+  const { updateHash, subscribe, getHashValues } = useHashState();
 
   // Skip 2D writes when the map move was initiated by a navigation (popstate)
   const navMoveInProgressRef = useRef(false);
+  // Remember the popstate target to avoid immediate re-pushing nearly identical coords
+  const popstateTargetRef = useRef<LatLngZoom | null>(null);
 
   const handleTopicMapLocationChange = useCallback(
     ({ lat, lng, zoom }: LatLngZoom) => {
       if (!isMode2d) return;
-      if (navMoveInProgressRef.current) return;
+      if (navMoveInProgressRef.current) {
+        console.debug(
+          "[Routing][hash] (2D) suppress push: popstate navigation in progress",
+          {
+            lat,
+            lng,
+            zoom,
+            label: labels?.topicMapLocation ?? "Map:2D:location",
+          }
+        );
+        return;
+      }
+      // If we just restored to a target via popstate, allow small drift without pushing
+      const target = popstateTargetRef.current;
+      if (target) {
+        const tol = 3e-5; // ~3 meters
+        const nearLat = Math.abs(lat - target.lat) <= tol;
+        const nearLng = Math.abs(lng - target.lng) <= tol;
+        const sameZoom = Math.abs(zoom - target.zoom) < 1e-6;
+        if (nearLat && nearLng && sameZoom) {
+          console.debug(
+            "[Routing][hash] (2D) skip push: equals popstate target within tolerance",
+            { lat, lng, zoom, target }
+          );
+          popstateTargetRef.current = null;
+          return;
+        }
+      }
+      // Skip writing if the map is already at the current hash location (within tolerance)
+      try {
+        const vals = getHashValues?.() || {};
+        const hLat = Number((vals as Record<string, unknown>).lat);
+        const hLng = Number((vals as Record<string, unknown>).lng);
+        const hZoom = Number((vals as Record<string, unknown>).zoom);
+        const tol = 3e-5; // ~3 meters
+        const sameLat = Number.isFinite(hLat) && Math.abs(lat - hLat) <= tol;
+        const sameLng = Number.isFinite(hLng) && Math.abs(lng - hLng) <= tol;
+        const sameZoom =
+          Number.isFinite(hZoom) && Math.abs(zoom - hZoom) < 1e-6;
+        if (sameLat && sameLng && sameZoom) {
+          console.debug(
+            "[Routing][hash] (2D) skip push: equals current hash within tolerance",
+            { lat, lng, zoom, hLat, hLng, hZoom }
+          );
+          return;
+        }
+      } catch {}
       updateHash(
         { lat, lng, zoom },
         {
@@ -54,7 +102,13 @@ export function useMapHashRouting({
         }
       );
     },
-    [isMode2d, updateHash, cesiumClearKeys, labels?.topicMapLocation]
+    [
+      isMode2d,
+      updateHash,
+      getHashValues,
+      cesiumClearKeys,
+      labels?.topicMapLocation,
+    ]
   );
 
   const handleCesiumSceneChange = useCallback(
@@ -120,13 +174,27 @@ export function useMapHashRouting({
         const map = getLeafletMap?.();
         if (!map) return;
         navMoveInProgressRef.current = true;
-        const clearNavFlag = () => {
-          navMoveInProgressRef.current = false;
+        popstateTargetRef.current = { lat, lng, zoom };
+        console.debug("[Routing][hash] popstate begin -> restore 2D view", {
+          lat,
+          lng,
+          zoom,
+        });
+        const scheduleClear = (evt: string) => {
+          if (typeof map.once === "function") {
+            map.once(evt, () => {
+              setTimeout(() => {
+                navMoveInProgressRef.current = false;
+                console.debug(
+                  "[Routing][hash] popstate end -> resume 2D writes",
+                  { via: evt }
+                );
+              }, 0);
+            });
+          }
         };
-        if (typeof map.once === "function") {
-          map.once("moveend", clearNavFlag);
-          map.once("zoomend", clearNavFlag);
-        }
+        scheduleClear("moveend");
+        scheduleClear("zoomend");
         if (typeof map.setView === "function") {
           map.setView({ lat, lng }, zoom);
         } else if (typeof map.panTo === "function") {

--- a/libraries/appframeworks/portals/src/lib/hooks/useMapHashRouting.ts
+++ b/libraries/appframeworks/portals/src/lib/hooks/useMapHashRouting.ts
@@ -18,6 +18,7 @@ type LeafletLikeMap = {
   panTo?: (center: { lat: number; lng: number }) => void;
   setZoom?: (zoom: number) => void;
   getCenter?: () => { lat: number; lng: number };
+  once?: (type: string, fn: (...args: unknown[]) => void) => void;
 };
 
 export interface UseMapHashRoutingOptions {
@@ -37,13 +38,13 @@ export function useMapHashRouting({
 }: UseMapHashRoutingOptions) {
   const { updateHash, subscribe } = useHashState();
 
-  // Prevent write loops when we programmatically move the map due to history navigation
-  const suppressWriteRef = useRef(false);
+  // Skip 2D writes when the map move was initiated by a navigation (popstate)
+  const navMoveInProgressRef = useRef(false);
 
   const handleTopicMapLocationChange = useCallback(
     ({ lat, lng, zoom }: LatLngZoom) => {
       if (!isMode2d) return;
-      if (suppressWriteRef.current) return;
+      if (navMoveInProgressRef.current) return;
       updateHash(
         { lat, lng, zoom },
         {
@@ -117,18 +118,19 @@ export function useMapHashRouting({
         if (lat == null || lng == null || zoom == null) return;
         const map = getLeafletMap?.();
         if (!map) return;
-        suppressWriteRef.current = true;
-        try {
-          if (typeof map.setView === "function") {
-            map.setView({ lat, lng }, zoom);
-          } else if (typeof map.panTo === "function") {
-            map.panTo({ lat, lng });
-            if (typeof map.setZoom === "function") map.setZoom(zoom);
-          }
-        } finally {
-          setTimeout(() => {
-            suppressWriteRef.current = false;
-          }, 50);
+        navMoveInProgressRef.current = true;
+        const clearNavFlag = () => {
+          navMoveInProgressRef.current = false;
+        };
+        if (typeof map.once === "function") {
+          map.once("moveend", clearNavFlag);
+          map.once("zoomend", clearNavFlag);
+        }
+        if (typeof map.setView === "function") {
+          map.setView({ lat, lng }, zoom);
+        } else if (typeof map.panTo === "function") {
+          map.panTo({ lat, lng });
+          if (typeof map.setZoom === "function") map.setZoom(zoom);
         }
       },
       { keys: ["lat", "lng", "zoom"] }

--- a/libraries/appframeworks/portals/src/lib/hooks/useMapHashRouting.ts
+++ b/libraries/appframeworks/portals/src/lib/hooks/useMapHashRouting.ts
@@ -50,6 +50,7 @@ export function useMapHashRouting({
         {
           clearKeys: cesiumClearKeys,
           label: labels?.topicMapLocation ?? "Map:2D:location",
+          replace: false,
         }
       );
     },

--- a/libraries/commons/utils/src/index.ts
+++ b/libraries/commons/utils/src/index.ts
@@ -6,14 +6,23 @@ export { extractCarmaConfig } from "./lib/carmaConfig";
 
 export { md5FetchText, md5ActionFetchDAQ } from "./lib/fetching";
 
-export { extractInformation } from "./lib/layer-parser";
-
 export {
   getGazData,
   type GazDataItem,
   type GazDataConfig,
   type GazDataSourceConfig,
 } from "./lib/gazData";
+
+export {
+  metersPerPixel,
+  distanceMeters,
+  pixelsBetweenLocations,
+  isLocationEqualWithinPixelTolerance,
+  type LatLng,
+  type LatLngZoom,
+} from "./lib/geo";
+
+export { extractInformation } from "./lib/layer-parser";
 
 export { suppressReactCismapErrors } from "./lib/log-react-cismap-errors";
 
@@ -29,7 +38,11 @@ export {
   convertBBox2Bounds,
 } from "./lib/proj4helpers";
 
-export { updateHashHistoryState, getHashParams } from "./lib/routing.ts";
+export {
+  updateHashHistoryState,
+  getHashParams,
+  diffHashParams,
+} from "./lib/routing.ts";
 
 export { generateRandomString } from "./lib/strings";
 

--- a/libraries/commons/utils/src/lib/geo.ts
+++ b/libraries/commons/utils/src/lib/geo.ts
@@ -1,0 +1,62 @@
+import { distance } from "@turf/turf";
+
+export type LatLng = { lat: number; lng: number };
+export type LatLngZoom = { lat: number; lng: number; zoom: number };
+
+export function metersPerPixel(zoom: number, latitude?: number): number {
+  // Default to ~50° latitude if none provided
+  const lat = latitude ?? 50;
+  const cosLat = Math.cos((lat * Math.PI) / 180);
+  const metersPerPixelAtEquator = 156543.03392804097; // Web Mercator
+  return (metersPerPixelAtEquator * cosLat) / Math.pow(2, zoom);
+}
+
+export function distanceMeters(a: LatLng, b: LatLng): number {
+  // Turf distance in kilometers by default; specify meters
+  return distance([a.lng, a.lat], [b.lng, b.lat], { units: "meters" });
+}
+
+export function pixelsBetweenLocations(
+  a: LatLng,
+  b: LatLng,
+  zoomRef: number
+): number {
+  // Use the maximum absolute latitude of the two points for Web Mercator scale
+  const latForScale = Math.max(Math.abs(a.lat || 0), Math.abs(b.lat || 0));
+  const mPerPx = metersPerPixel(zoomRef, latForScale);
+  const dMeters = distanceMeters(a, b);
+  return dMeters / mPerPx;
+}
+
+export function isZoomClose(
+  a: number | undefined,
+  b: number | undefined,
+  tol: number = 1e-6
+): boolean {
+  return (
+    Number.isFinite(a) &&
+    Number.isFinite(b) &&
+    Math.abs((a as number) - (b as number)) < tol
+  );
+}
+
+export function isLocationEqualWithinPixelTolerance(
+  a: LatLngZoom | undefined,
+  b: LatLngZoom | undefined,
+  opts?: {
+    pixelTolerance?: number; // in pixels
+    zoomTolerance?: number; // absolute zoom diff
+  }
+): boolean {
+  if (!a || !b) return false;
+  const pxTol = opts?.pixelTolerance ?? 2; // default 2px
+  const zoomTol = opts?.zoomTolerance ?? 1e-6;
+  if (!isZoomClose(a.zoom, b.zoom, zoomTol)) return false;
+  const px = pixelsBetweenLocations(
+    { lat: a.lat, lng: a.lng },
+    { lat: b.lat, lng: b.lng },
+    // use the target zoom to compute pixels at the on-screen scale we will write at
+    b.zoom
+  );
+  return px <= pxTol;
+}

--- a/libraries/commons/utils/src/lib/routing.ts
+++ b/libraries/commons/utils/src/lib/routing.ts
@@ -21,6 +21,13 @@ const sortArrayByKeys = (
     }
   });
 
+// A lightweight type for a React Router-like navigate function.
+// We avoid importing react-router here to keep this utility framework-agnostic.
+type NavigateLike = (
+  to: string,
+  opts?: { replace?: boolean; state?: unknown }
+) => void;
+
 /**
  * Get the stored parameters or parse them from the URL as fallback
  */
@@ -41,7 +48,13 @@ export const getHashParams = (hash?: string): Record<string, string> => {
 export const updateHashHistoryState = (
   hashParams: Record<string, string> = {},
   routedPath: string,
-  options: { removeKeys?: string[]; label?: string; keyOrder?: string[] } = {}
+  options: {
+    removeKeys?: string[];
+    label?: string;
+    keyOrder?: string[];
+    replace?: boolean; // if true: replace current entry; default false => push
+    navigate?: NavigateLike; // optional router navigate function
+  } = {}
 ) => {
   // this is method is used to avoid triggering rerenders from the HashRouter when updating the hash
   const currentParams = getHashParams();
@@ -54,6 +67,7 @@ export const updateHashHistoryState = (
   const removeKeys = options.removeKeys || [];
   const label = options.label || "N/A"; // for tracing debugging only
   const keyOrder = options.keyOrder || [];
+  const replace = options.replace === true; // default: push
 
   // remove keys that are in the removeKeys array
   removeKeys.forEach((key) => {
@@ -74,15 +88,39 @@ export const updateHashHistoryState = (
   });
 
   const combinedHash = combinedSearchParams.toString();
-  const fullHashState = `#${routedPath}?${combinedHash}`;
+  const toPath = `${routedPath}${combinedHash ? `?${combinedHash}` : ""}`;
+  const fullHashState = `#${toPath}`;
   // this is a workaround to avoid triggering rerenders from the HashRouter
   // navigate would cause rerenders
   // navigate(`${routedPath}?${formattedHash}`, { replace: true });
   // see https://github.com/remix-run/react-router/discussions/9851#discussioncomment-9459061
 
-  const currentUrl = new URL(window.location.href);
-  const newUrl = `${currentUrl.origin}${currentUrl.pathname}${fullHashState}`;
+  // Prefer router-aware navigation if provided
+  if (options.navigate) {
+    options.navigate(toPath, { replace });
+    console.debug(
+      `[Routing][react-router] (${label}): ${replace ? "Replace" : "Push"}`,
+      toPath
+    );
+    return;
+  }
 
-  window.history.replaceState(null, "", newUrl);
-  console.debug(`[Routing][window.history] (${label}): State Replace`, newUrl);
+  // Fallback to direct hash manipulation that emits 'hashchange'
+  // - Replace: use location.replace(...) to avoid adding history entries
+  // - Push: assign to location.hash to add a new history entry
+  if (replace) {
+    const currentUrl = new URL(window.location.href);
+    const newUrl = `${currentUrl.origin}${currentUrl.pathname}${fullHashState}`;
+    window.location.replace(newUrl);
+    console.debug(
+      `[Routing][window.location] (${label}): Hash Replace`,
+      newUrl
+    );
+  } else {
+    window.location.hash = toPath;
+    console.debug(
+      `[Routing][window.location] (${label}): Hash Push`,
+      `#${toPath}`
+    );
+  }
 };

--- a/libraries/commons/utils/src/lib/routing.ts
+++ b/libraries/commons/utils/src/lib/routing.ts
@@ -43,6 +43,32 @@ export const getHashParams = (hash?: string): Record<string, string> => {
 };
 
 /**
+ * Computes which keys changed and which were removed when going from `before` to `after`.
+ * Keys refer to the literal hash parameter names (aliasing not considered here).
+ */
+export const diffHashParams = (
+  before: Record<string, string>,
+  after: Record<string, string>
+) => {
+  const allKeys = new Set<string>([
+    ...Object.keys(before),
+    ...Object.keys(after),
+  ]);
+  const changedKeys: string[] = [];
+  const removedKeys: string[] = [];
+  allKeys.forEach((k) => {
+    if (before[k] !== after[k]) changedKeys.push(k);
+  });
+  Object.keys(before).forEach((k) => {
+    if (!(k in after)) removedKeys.push(k);
+  });
+  return {
+    changedKeys: [...new Set(changedKeys)],
+    removedKeys: [...new Set(removedKeys)],
+  };
+};
+
+/**
  * Updates the URL hash parameters without triggering a React Router navigation
  */
 export const updateHashHistoryState = (

--- a/libraries/commons/utils/src/lib/routing.ts
+++ b/libraries/commons/utils/src/lib/routing.ts
@@ -90,6 +90,14 @@ export const updateHashHistoryState = (
   const combinedHash = combinedSearchParams.toString();
   const toPath = `${routedPath}${combinedHash ? `?${combinedHash}` : ""}`;
   const fullHashState = `#${toPath}`;
+  // No-op: target equals current hash
+  if (window.location.hash === fullHashState) {
+    console.debug(
+      `[Routing] (noop): target hash equals current`,
+      fullHashState
+    );
+    return;
+  }
   // this is a workaround to avoid triggering rerenders from the HashRouter
   // navigate would cause rerenders
   // navigate(`${routedPath}?${formattedHash}`, { replace: true });

--- a/libraries/mapping/engines/cesium/src/lib/components/TopicMap.tsx
+++ b/libraries/mapping/engines/cesium/src/lib/components/TopicMap.tsx
@@ -73,6 +73,7 @@ export const TopicMap = ({ forceShow = false } = {}) => {
         gazData={[]}
         backgroundlayers="empty"
         hamburgerMenu={false}
+        pushToHistory={() => {}}
         fullScreenControlEnabled={false}
         zoomSnap={0.5} // TODO fix zoom snapping in TopicMap Component
         zoomDelta={0.5}

--- a/libraries/mapping/engines/cesium/src/lib/hooks/useOnSceneChange.ts
+++ b/libraries/mapping/engines/cesium/src/lib/hooks/useOnSceneChange.ts
@@ -55,6 +55,9 @@ export const useOnSceneChange = (
   useEffect(() => {
     // on changes to mode or style
     const viewer = viewerRef.current;
+    if (isTransitioning) {
+      return;
+    }
     if (viewer && viewer.camera && !isMode2d) {
       console.debug(
         "HOOK: update Hash, route or style changed",
@@ -73,7 +76,7 @@ export const useOnSceneChange = (
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [viewerRef, isMode2d, isSecondaryStyle]);
+  }, [viewerRef, isMode2d, isSecondaryStyle, isTransitioning]);
 
   useEffect(() => {
     // update hash hook

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
         "react-markdown-editor-lite": "^1.3.4",
         "react-pdf-html": "^1.1.19",
         "react-redux": "^9.1.2",
-        "react-router-dom": "^6.25.1",
+        "react-router-dom": "^7.8.1",
         "react-select": "^5.8.0",
         "react-simple-code-editor": "^0.14.1",
         "react-textarea-autosize": "^8.5.3",
@@ -14905,15 +14905,6 @@
       "resolved": "https://registry.npmjs.org/@rehooks/online-status/-/online-status-1.1.2.tgz",
       "integrity": "sha512-tuz6RtdgqkBMZr82UqTkzPCsHNx6tpEyhTZ5OD8WhDpU4/TLzljBCseuWLlbeQiygbM9F2A4Ea7P+wyjohJXBw==",
       "license": "MIT"
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.18.0.tgz",
-      "integrity": "sha512-L3jkqmqoSVBVKHfpGZmLrex0lxR5SucGA0sUfFzGctehw+S/ggL9L/0NnC5mw6P8HUWpFZ3nQw3cRApjjWx9Sw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/@renovate/pep440": {
       "version": "1.0.0",
@@ -52705,35 +52696,50 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.25.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.25.1.tgz",
-      "integrity": "sha512-u8ELFr5Z6g02nUtpPAggP73Jigj1mRePSwhS/2nkTrlPU5yEkH1vYzWNyvSnSzeeE2DNqWdH+P8OhIh9wuXhTw==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.1.tgz",
+      "integrity": "sha512-5cy/M8DHcG51/KUIka1nfZ2QeylS4PJRs6TT8I4PF5axVsI5JUxp0hC0NZ/AEEj8Vw7xsEoD7L/6FY+zoYaOGA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.18.0"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.25.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.25.1.tgz",
-      "integrity": "sha512-0tUDpbFvk35iv+N89dWNrJp+afLgd+y4VtorJZuOCXK0kkCWjEvb3vTJM++SYvMEpbVwXKf3FjeVveVEb6JpDQ==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.1.tgz",
+      "integrity": "sha512-NkgBCF3sVgCiAWIlSt89GR2PLaksMpoo3HDCorpRfnCEfdtRPLiuTf+CNXvqZMI5SJLZCLpVCvcZrTdtGW64xQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.18.0",
-        "react-router": "6.25.1"
+        "react-router": "7.8.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/react-scroll": {
@@ -54519,6 +54525,12 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "react-markdown-editor-lite": "^1.3.4",
     "react-pdf-html": "^1.1.19",
     "react-redux": "^9.1.2",
-    "react-router-dom": "^6.25.1",
+    "react-router-dom": "^7.8.1",
     "react-select": "^5.8.0",
     "react-simple-code-editor": "^0.14.1",
     "react-textarea-autosize": "^8.5.3",

--- a/playgrounds/carmamap/src/app/components/CarmaMap/CarmaMap.tsx
+++ b/playgrounds/carmamap/src/app/components/CarmaMap/CarmaMap.tsx
@@ -547,7 +547,6 @@ export const CarmaMap = ({
               {createCismapLayers(layers, {
                 mode: uiMode,
                 dispatch,
-                zoom: getLeafletZoom(),
               })}
               {hqKey && <HGKWMSTLayer hqKey={hqKey} />}
             </TopicMapComponent>

--- a/playgrounds/carmamap/src/app/components/CarmaMap/CarmaMap.tsx
+++ b/playgrounds/carmamap/src/app/components/CarmaMap/CarmaMap.tsx
@@ -174,10 +174,8 @@ export const CarmaMap = ({
   );
 
   const topicMapLocationChangedHandler = (location: Location) => {
-    (location) => {
-      const newParams = { ...paramsToObject(urlParams), ...location };
-      setUrlParams(newParams);
-    };
+    const newParams = { ...paramsToObject(urlParams), ...location };
+    setUrlParams(newParams, { replace: false });
   };
 
   const is2dOnlyParamSet = urlParams.get(PARAMS.ONLY_2D) !== null;
@@ -510,6 +508,7 @@ export const CarmaMap = ({
                 // console.debug('xxx bbox', createWMSBbox(boundingbox));
               }}
               locationChangedHandler={topicMapLocationChangedHandler}
+              outerLocationChangedHandlerExclusive={true}
               onclick={(e) => {
                 const map = routedMap.leafletMap.leafletElement;
                 const baseUrl =
@@ -579,6 +578,7 @@ export const CarmaMap = ({
                   updateHashHistoryState(e.hashParams, "/", {
                     removeKeys: ["zoom"],
                     label: "app/carma:3D",
+                    replace: true,
                   });
                 }}
               ></CustomViewer>

--- a/playgrounds/carmamap/src/app/components/CarmaMap/CarmaMap.tsx
+++ b/playgrounds/carmamap/src/app/components/CarmaMap/CarmaMap.tsx
@@ -15,7 +15,6 @@ import {
   Math as CesiumMath,
   CesiumTerrainProvider,
   Color,
-  Terrain,
 } from "cesium";
 
 import {
@@ -26,8 +25,6 @@ import {
 } from "@carma-mapping/map-controls-layout";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
-  faCompress,
-  faExpand,
   faHouseChimney,
   faMinus,
   faPlus,
@@ -46,6 +43,7 @@ import {
   useSelection,
   useSelectionCesium,
   useSelectionTopicMap,
+  useHashState,
 } from "@carma-apps/portals";
 import {
   getCollabedHelpComponentConfig,
@@ -55,7 +53,6 @@ import {
 import {
   detectWebGLContext,
   getApplicationVersion,
-  updateHashHistoryState,
 } from "@carma-commons/utils";
 
 import {
@@ -77,8 +74,6 @@ import { LibFuzzySearch } from "@carma-mapping/fuzzy-search";
 import { type SearchResultItem } from "@carma-commons/types";
 
 import versionData from "../../../version.json";
-
-import { paramsToObject } from "../../helper/helper.ts";
 import { getBackgroundLayers } from "../../helper/layer.tsx";
 
 import { useWindowSize } from "../../hooks/useWindowSize.ts";
@@ -173,9 +168,16 @@ export const CarmaMap = ({
     "HQ500"
   );
 
-  const topicMapLocationChangedHandler = (location: Location) => {
-    const newParams = { ...paramsToObject(urlParams), ...location };
-    setUrlParams(newParams, { replace: false });
+  const topicMapLocationChangedHandler = (loc: {
+    lat: number;
+    lng: number;
+    zoom: number;
+  }) => {
+    const params = new URLSearchParams(urlParams);
+    params.set("lat", String(loc.lat));
+    params.set("lng", String(loc.lng));
+    params.set("zoom", String(loc.zoom));
+    setUrlParams(params, { replace: false });
   };
 
   const is2dOnlyParamSet = urlParams.get(PARAMS.ONLY_2D) !== null;
@@ -225,6 +227,7 @@ export const CarmaMap = ({
   const { width, height } = useWindowSize(wrapperRef);
 
   const { setSelection } = useSelection();
+  const { updateHash } = useHashState();
 
   useSelectionTopicMap();
   useSelectionCesium(
@@ -504,7 +507,7 @@ export const CarmaMap = ({
               leafletMapProps={{ editable: true }}
               minZoom={10}
               backgroundlayers="empty"
-              mappingBoundsChanged={(boundingbox) => {
+              mappingBoundsChanged={() => {
                 // console.debug('xxx bbox', createWMSBbox(boundingbox));
               }}
               locationChangedHandler={topicMapLocationChangedHandler}
@@ -575,8 +578,8 @@ export const CarmaMap = ({
                     "[GEOPORTALMAP|HASH|SCENE|CESIUM]cesium scene changed",
                     e
                   );
-                  updateHashHistoryState(e.hashParams, "/", {
-                    removeKeys: ["zoom"],
+                  updateHash(e.hashParams, {
+                    clearKeys: ["zoom"],
                     label: "app/carma:3D",
                     replace: true,
                   });

--- a/playgrounds/carmamap/src/app/components/CarmaMap/CarmaMap.tsx
+++ b/playgrounds/carmamap/src/app/components/CarmaMap/CarmaMap.tsx
@@ -547,6 +547,7 @@ export const CarmaMap = ({
               {createCismapLayers(layers, {
                 mode: uiMode,
                 dispatch,
+                zoom: getLeafletZoom(),
               })}
               {hqKey && <HGKWMSTLayer hqKey={hqKey} />}
             </TopicMapComponent>

--- a/playgrounds/cesium/src/app/App.tsx
+++ b/playgrounds/cesium/src/app/App.tsx
@@ -8,6 +8,7 @@ import {
   CesiumContextProvider,
 } from "@carma-mapping/cesium-engine";
 import { TweakpaneProvider } from "@carma-commons/debug";
+import { HashStateProvider } from "@carma-apps/portals";
 import {
   BASEMAP_METROPOLRUHR_WMS_GRAUBLAU,
   METROPOLERUHR_WMTS_SPW2_WEBMERCATOR,
@@ -41,38 +42,41 @@ export function App() {
     >
       <TweakpaneProvider>
         <HashRouter>
-          <Navigation
-            className="leaflet-bar"
-            style={{
-              position: "absolute",
-              top: 8,
-              left: "50%",
-              width: "auto",
-              display: "flex",
-              justifyContent: "center",
-              transform: "translate(-50%, 0)",
-              zIndex: 10,
-            }}
-            routes={[...viewerRoutes, ...otherRoutes]}
-          />
-          <Routes>
-            <Route
-              path="/*"
-              element={
-                <TopicMapContextProvider>
-                  <CustomViewerPlayground
-                    minimapLayerUrl={
-                      METROPOLERUHR_WMTS_SPW2_WEBMERCATOR.layers["spw2_orange"]
-                        .url
-                    }
-                  >
-                    <Routes>{...ViewerRoutes}</Routes>
-                  </CustomViewerPlayground>
-                </TopicMapContextProvider>
-              }
+          <HashStateProvider>
+            <Navigation
+              className="leaflet-bar"
+              style={{
+                position: "absolute",
+                top: 8,
+                left: "50%",
+                width: "auto",
+                display: "flex",
+                justifyContent: "center",
+                transform: "translate(-50%, 0)",
+                zIndex: 10,
+              }}
+              routes={[...viewerRoutes, ...otherRoutes]}
             />
-            {...OtherRoutes}
-          </Routes>
+            <Routes>
+              <Route
+                path="/*"
+                element={
+                  <TopicMapContextProvider>
+                    <CustomViewerPlayground
+                      minimapLayerUrl={
+                        METROPOLERUHR_WMTS_SPW2_WEBMERCATOR.layers[
+                          "spw2_orange"
+                        ].url
+                      }
+                    >
+                      <Routes>{ViewerRoutes}</Routes>
+                    </CustomViewerPlayground>
+                  </TopicMapContextProvider>
+                }
+              />
+              {OtherRoutes}
+            </Routes>
+          </HashStateProvider>
         </HashRouter>
       </TweakpaneProvider>
     </CesiumContextProvider>

--- a/playgrounds/cesium/src/app/views/tests/standalone/HQ500.tsx
+++ b/playgrounds/cesium/src/app/views/tests/standalone/HQ500.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
-import { useLocation } from "react-router-dom";
 
-import { CesiumTerrainProvider, Color, Terrain, TerrainProvider } from "cesium";
+import { CesiumTerrainProvider, Color, Terrain } from "cesium";
 
 import {
   Control,
@@ -18,21 +17,19 @@ import {
 
 import {
   CustomViewer,
-  Compass,
   useCesiumContext,
   useHomeControl,
   useZoomControls as useZoomControlsCesium,
 } from "@carma-mapping/cesium-engine";
 import { useTweakpaneCtx } from "@carma-commons/debug";
-import { updateHashHistoryState } from "@carma-commons/utils";
+import { useHashState } from "@carma-apps/portals";
 
 import "cesium/Build/Cesium/Widgets/widgets.css";
 
 const TERRAIN_HQ500_CM = "https://cesium-wupp-terrain.cismet.de/HQ500cm/";
-const TERRAIN_HQ500 = "https://cesium-wupp-terrain.cismet.de/HQ500/";
 
 export const HQ500 = () => {
-  const location = useLocation();
+  const { updateHash } = useHashState();
 
   const rerenderCountRef = useRef(0);
   const lastRenderTimeStampRef = useRef(Date.now());
@@ -91,7 +88,7 @@ export const HQ500 = () => {
 
   useEffect(() => {
     if (viewer && hq500Terrain && primaryTileset) {
-      const onTerrainReady = (terrainProvider: TerrainProvider) => {
+      const onTerrainReady = () => {
         primaryTileset.show = true;
         viewer.scene.setTerrain(hq500Terrain);
         viewer.scene.backgroundColor = Color.DIMGREY;
@@ -168,8 +165,8 @@ export const HQ500 = () => {
                 "[GEOPORTALMAP|HASH|SCENE|CESIUM]cesium scene changed",
                 e
               );
-              updateHashHistoryState(e.hashParams, location.pathname, {
-                removeKeys: ["zoom"],
+              updateHash(e.hashParams, {
+                clearKeys: ["zoom"],
                 label: "app/hq500:3D",
               });
             }}

--- a/playgrounds/cesium/vite.config.mts
+++ b/playgrounds/cesium/vite.config.mts
@@ -72,7 +72,7 @@ export default defineConfig({
   build: {
     outDir: '../../dist/playgrounds/cesium',
     reportCompressedSize: true,
-    sourcemap: true, // while not in actual production,
+    sourcemap: false,
     commonjsOptions: { transformMixedEsModules: true },
     rollupOptions: {
       onwarn: (warning, warn) => {


### PR DESCRIPTION
- [x] by default write to history on leaflet map action move/zoom.
- [x] update leaflet map on navigation with move or zoom. 
- [x] update current hash navigation hook useHashState to handle url hash encode decode but use react router useNavigate inside the hook not just custom hash state update code. Keep hook interface the same if possible.
- [x] either allow navigation back to 2d from 3d without transition animation or disable history navigation when in 3d mode or force reload of app on navigation actions in 3d mode.
- [x] discuss handling of map styles and mode restoration on navigation actions
- [x] ideally those state restore should use same methods and hooks as initialization routines for  leaflet, maplibre and cesium.
- [x] make this extensible to any app state thats reflected in the url. at worst force reinitialization of app, at best have sensible transitions.
- this should all be managed by the browser history and parsing from url, not some second internal app state history.