### PR TITLE
fix: prevent hashchange events from triggering React Router rerenders

### DIFF
--- a/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
+++ b/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
@@ -1,6 +1,13 @@
 import L from "leaflet";
 import proj4 from "proj4";
-import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { Button, Tooltip } from "antd";
@@ -168,6 +175,7 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
   // TODO: move all these to a custom hook and collect all calls to updateFeatureInfo there
   const [shouldUpdateFeatureInfo, setShouldUpdateFeatureInfo] =
     useState<boolean>(false);
+  const layersIdle = useSelector(getLayersIdle);
 
   const version = getApplicationVersion(versionData);
 
@@ -176,6 +184,13 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
   const { isDebugMode } = flags;
   const cesiumInitialCameraView = useCesiumInitialCameraFromSearchParams();
   const { isObliqueMode } = useObliqueInitializer(isDebugMode);
+
+  const updateLayersIdleState = useCallback(() => {
+    if (layersIdle) {
+      console.debug("Layers are idle, setting layers idle to false");
+      dispatch(setLayersIdle(false));
+    }
+  }, [layersIdle, dispatch]);
 
   useDispatchSachdatenInfoText();
   const modelSelectionDispatcher = useModelSelectionDispatcher();
@@ -373,13 +388,13 @@ export const GeoportalMap = ({ height, width, allow3d }: MapProps) => {
       createLocationChangeHandler({
         isMode2d,
         onChange: handleTopicMapLocationChange,
-        onAfter: () => dispatch(setLayersIdle(false)),
+        onAfter: updateLayersIdleState,
         onMismatch: () =>
           console.debug(
             "[TopicMap|DEBUG] Location changed handler triggered while in 3D mode"
           ),
       }),
-    [isMode2d, handleTopicMapLocationChange, dispatch]
+    [isMode2d, handleTopicMapLocationChange, updateLayersIdleState]
   );
 
   const onSceneChange = (e: { hashParams: Record<string, string> }) => {

--- a/apps/geoportal/src/app/components/TopNavbar.tsx
+++ b/apps/geoportal/src/app/components/TopNavbar.tsx
@@ -178,8 +178,8 @@ const TopNavbar = () => {
               onClick={showOverlayHandler}
               data-test-id="helper-overlay-btn"
               ref={helpOverlayTourRef}
-              onMouseEnter={handleHideHelpTooltip}
-              onMouseLeave={handleShowHelpTooltip}
+              onMouseEnter={handleShowHelpTooltip}
+              onMouseLeave={handleHideHelpTooltip}
             >
               <FontAwesomeIcon
                 className="h-[24px] pt-1"

--- a/apps/geoportal/src/app/components/TopNavbar.tsx
+++ b/apps/geoportal/src/app/components/TopNavbar.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useContext, useMemo, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { faCircleQuestion } from "@fortawesome/free-regular-svg-icons";
 import {
   faBars,
@@ -9,12 +11,9 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Button, Radio, Tooltip } from "antd";
-import { useContext, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
 
 import { UIDispatchContext } from "react-cismap/contexts/UIContextProvider";
 
-import { useFeatureFlags } from "@carma-providers/feature-flag";
 import { geoElements } from "@carma-collab/wuppertal/geoportal";
 import { getCollabedHelpComponentConfig as getCollabedHelpElementsConfig } from "@carma-collab/wuppertal/helper-overlay";
 import {
@@ -23,6 +22,7 @@ import {
 } from "@carma-commons/ui/helper-overlay";
 import { cn } from "@carma-commons/utils";
 import { selectViewerIsMode2d } from "@carma-mapping/engines/cesium";
+import { useFeatureFlags } from "@carma-providers/feature-flag";
 
 import {
   getBackgroundLayer,
@@ -62,23 +62,67 @@ const TopNavbar = () => {
   const selectedLuftbildLayer = useSelector(getSelectedLuftbildLayer);
   const zenMode = useSelector(getZenMode);
 
-  const hintergrundTourRef = useOverlayHelper(
-    getCollabedHelpElementsConfig("HINTERGRUND", geoElements)
+  const hintergrundConfig = useMemo(
+    () => getCollabedHelpElementsConfig("HINTERGRUND", geoElements),
+    []
   );
-  const modalMenuTourRef = useOverlayHelper(
-    getCollabedHelpElementsConfig("MENU", geoElements)
+  const modalMenuConfig = useMemo(
+    () => getCollabedHelpElementsConfig("MENU", geoElements),
+    []
   );
-  const helpOverlayTourRef = useOverlayHelper({
-    ...getCollabedHelpElementsConfig("HILFE_OVERLAY", geoElements),
-    primary: {
-      ...getCollabedHelpElementsConfig("HILFE_OVERLAY", geoElements).primary,
-      minWindowSize: 1024,
-    },
-  });
 
-  const toggleMobileMenu = () => {
+  const hintergrundTourRef = useOverlayHelper(hintergrundConfig);
+  const modalMenuTourRef = useOverlayHelper(modalMenuConfig);
+
+  const overlayConfig = useMemo(() => {
+    return {
+      ...getCollabedHelpElementsConfig("HILFE_OVERLAY", geoElements),
+      primary: {
+        ...getCollabedHelpElementsConfig("HILFE_OVERLAY", geoElements).primary,
+        minWindowSize: 1024,
+      },
+    };
+  }, []);
+
+  const helpOverlayTourRef = useOverlayHelper(overlayConfig);
+
+  const toggleMobileMenu = useCallback(() => {
     setMobileMenuOpen(!mobileMenuOpen);
-  };
+  }, [mobileMenuOpen]);
+
+  const handleShowHelpTooltip = useCallback(() => {
+    setShowHelpTooltip(true);
+  }, []);
+
+  const handleHideHelpTooltip = useCallback(() => {
+    setShowHelpTooltip(false);
+  }, []);
+
+  const handleBackgroundLayerChange = useCallback(
+    (e: Event) => {
+      e.stopPropagation();
+      if (e.target.value === "openBaseLayerView") {
+        dispatch(setSelectedLayerIndex(-1));
+      } else if (e.target.value === MapStyleKeys.TOPO) {
+        setCurrentStyle(MapStyleKeys.TOPO);
+      } else if (e.target.value === MapStyleKeys.AERIAL) {
+        setCurrentStyle(MapStyleKeys.AERIAL);
+      }
+    },
+    [dispatch, setCurrentStyle]
+  );
+
+  const handleAppMenuVisible = useCallback(() => {
+    setAppMenuVisible(true);
+  }, []); // setAppMenuVisible from context is stable
+
+  const mainStyle = useMemo(() => {
+    return {
+      visibility: zenMode ? "hidden" : undefined,
+      display: zenMode ? "none" : "flex",
+      zIndex: 10000,
+    };
+  }, [zenMode]);
 
   console.debug("RENDER: TopNavbar");
 
@@ -90,11 +134,7 @@ const TopNavbar = () => {
         py-2 pt-safe-top pb-safe-bottom \
         pl-safe-left xs:pl-safe-left-xs pr-safe-right xs:pr-safe-right-xs"
       }
-      style={{
-        visibility: zenMode ? "hidden" : undefined,
-        display: zenMode ? "none" : "flex",
-        zIndex: 10000,
-      }}
+      style={mainStyle}
     >
       <ResourceModal />
 
@@ -138,8 +178,8 @@ const TopNavbar = () => {
               onClick={showOverlayHandler}
               data-test-id="helper-overlay-btn"
               ref={helpOverlayTourRef}
-              onMouseEnter={() => setShowHelpTooltip(true)}
-              onMouseLeave={() => setShowHelpTooltip(false)}
+              onMouseEnter={handleHideHelpTooltip}
+              onMouseLeave={handleShowHelpTooltip}
             >
               <FontAwesomeIcon
                 className="h-[24px] pt-1"
@@ -169,16 +209,7 @@ const TopNavbar = () => {
             {backgroundLayer && (
               <Radio.Group
                 value={backgroundLayer.id}
-                onChange={(e) => {
-                  e.stopPropagation();
-                  if (e.target.value === "openBaseLayerView") {
-                    dispatch(setSelectedLayerIndex(-1));
-                  } else if (e.target.value === MapStyleKeys.TOPO) {
-                    setCurrentStyle(MapStyleKeys.TOPO);
-                  } else if (e.target.value === MapStyleKeys.AERIAL) {
-                    setCurrentStyle(MapStyleKeys.AERIAL);
-                  }
-                }}
+                onChange={handleBackgroundLayerChange}
               >
                 <Tooltip
                   title={
@@ -222,9 +253,7 @@ const TopNavbar = () => {
 
           <Tooltip title="Kompaktanleitung | Login">
             <Button
-              onClick={() => {
-                setAppMenuVisible(true);
-              }}
+              onClick={handleAppMenuVisible}
               ref={modalMenuTourRef}
               data-test-id="modal-menu-btn"
               className="select-none"

--- a/apps/geoportal/src/app/components/TopNavbar.tsx
+++ b/apps/geoportal/src/app/components/TopNavbar.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useContext, useMemo, useState } from "react";
+import {
+  type CSSProperties,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { faCircleQuestion } from "@fortawesome/free-regular-svg-icons";
 import {
@@ -10,7 +16,7 @@ import {
   faPlane,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Button, Radio, Tooltip } from "antd";
+import { Button, Radio, type RadioChangeEvent, Tooltip } from "antd";
 
 import { UIDispatchContext } from "react-cismap/contexts/UIContextProvider";
 
@@ -99,7 +105,7 @@ const TopNavbar = () => {
   }, []);
 
   const handleBackgroundLayerChange = useCallback(
-    (e: Event) => {
+    (e: RadioChangeEvent) => {
       e.stopPropagation();
       if (e.target.value === "openBaseLayerView") {
         dispatch(setSelectedLayerIndex(-1));
@@ -116,7 +122,7 @@ const TopNavbar = () => {
     setAppMenuVisible(true);
   }, []); // setAppMenuVisible from context is stable
 
-  const mainStyle = useMemo(() => {
+  const mainStyle = useMemo((): CSSProperties => {
     return {
       visibility: zenMode ? "hidden" : undefined,
       display: zenMode ? "none" : "flex",

--- a/libraries/appframeworks/portals/src/lib/contexts/HashStateProvider.tsx
+++ b/libraries/appframeworks/portals/src/lib/contexts/HashStateProvider.tsx
@@ -172,7 +172,7 @@ export const HashStateProvider: React.FC<{
         keyOrder,
         label: label || "unspecified",
         replace,
-        navigate,
+        //navigate,
       });
 
       const afterRaw = getHashParams();

--- a/libraries/appframeworks/portals/src/lib/hooks/useMapHashRouting.ts
+++ b/libraries/appframeworks/portals/src/lib/hooks/useMapHashRouting.ts
@@ -144,7 +144,7 @@ export function useMapHashRouting({
       updateHash(e.hashParams, {
         clearKeys: ["zoom"],
         label: labels?.cesiumScene ?? "Map:3D:scene",
-        replace: true,
+        replace: true, // don't push to history until cesium handled history navigation
       });
     },
     [isMode2d, updateHash, labels?.cesiumScene]

--- a/libraries/commons/utils/src/lib/routing.ts
+++ b/libraries/commons/utils/src/lib/routing.ts
@@ -1,3 +1,4 @@
+import { normalizeOptions } from "./normalizeOptions";
 const sortArrayByKeys = (
   arr: [string, unknown][],
   keyOrder: string[],
@@ -20,13 +21,6 @@ const sortArrayByKeys = (
       return sortRestAlphabetically ? keyA.localeCompare(keyB) : 0;
     }
   });
-
-// A lightweight type for a React Router-like navigate function.
-// We avoid importing react-router here to keep this utility framework-agnostic.
-type NavigateLike = (
-  to: string,
-  opts?: { replace?: boolean; state?: unknown }
-) => void;
 
 /**
  * Get the stored parameters or parse them from the URL as fallback
@@ -71,16 +65,27 @@ export const diffHashParams = (
 /**
  * Updates the URL hash parameters without triggering a React Router navigation
  */
+
+interface updateHashHistoryStateOptions {
+  removeKeys?: string[];
+  label?: string;
+  keyOrder?: string[];
+  replace?: boolean; // if true: replace current entry; default false => push
+  debug?: boolean;
+}
+
+const defaultOptions: Required<updateHashHistoryStateOptions> = {
+  removeKeys: [],
+  label: "N/A",
+  keyOrder: [],
+  replace: false,
+  debug: false,
+};
+
 export const updateHashHistoryState = (
   hashParams: Record<string, string> = {},
   routedPath: string,
-  options: {
-    removeKeys?: string[];
-    label?: string;
-    keyOrder?: string[];
-    replace?: boolean; // if true: replace current entry; default false => push
-    navigate?: NavigateLike; // optional router navigate function
-  } = {}
+  options: updateHashHistoryStateOptions
 ) => {
   // this is method is used to avoid triggering rerenders from the HashRouter when updating the hash
   const currentParams = getHashParams();
@@ -90,10 +95,10 @@ export const updateHashHistoryState = (
     ...hashParams, // overwrite from state but keep others
   };
 
-  const removeKeys = options.removeKeys || [];
-  const label = options.label || "N/A"; // for tracing debugging only
-  const keyOrder = options.keyOrder || [];
-  const replace = options.replace === true; // default: push
+  const { removeKeys, label, keyOrder, replace, debug } = normalizeOptions(
+    options,
+    defaultOptions
+  );
 
   // remove keys that are in the removeKeys array
   removeKeys.forEach((key) => {
@@ -124,37 +129,31 @@ export const updateHashHistoryState = (
     );
     return;
   }
-  // this is a workaround to avoid triggering rerenders from the HashRouter
-  // navigate would cause rerenders
+  // Avoid React Router's navigate() to prevent cascade rerenders
+  // - navigate() triggers React Router rerenders and component cascades
   // navigate(`${routedPath}?${formattedHash}`, { replace: true });
   // see https://github.com/remix-run/react-router/discussions/9851#discussioncomment-9459061
 
-  // Prefer router-aware navigation if provided
-  if (options.navigate) {
-    options.navigate(toPath, { replace });
-    console.debug(
-      `[Routing][react-router] (${label}): ${replace ? "Replace" : "Push"}`,
-      toPath
-    );
-    return;
-  }
+  // History API that doesn't emit 'hashchange' events (prevents React Router rerenders)
+  // Use History API to update URL without triggering hashchange events
+  const currentUrl = new URL(window.location.href);
+  const newUrl = `${currentUrl.origin}${currentUrl.pathname}${fullHashState}`;
 
-  // Fallback to direct hash manipulation that emits 'hashchange'
-  // - Replace: use location.replace(...) to avoid adding history entries
-  // - Push: assign to location.hash to add a new history entry
   if (replace) {
-    const currentUrl = new URL(window.location.href);
-    const newUrl = `${currentUrl.origin}${currentUrl.pathname}${fullHashState}`;
+    // not navigable just updates the current hash
     window.location.replace(newUrl);
-    console.debug(
-      `[Routing][window.location] (${label}): Hash Replace`,
-      newUrl
-    );
+    debug &&
+      console.debug(
+        `[Routing][window.location] (${label}): Hash Replace`,
+        `#${toPath}`
+      );
   } else {
-    window.location.hash = toPath;
-    console.debug(
-      `[Routing][window.location] (${label}): Hash Push`,
-      `#${toPath}`
-    );
+    // navigable Push: assign to location.hash to add a new history entry
+    window.history.pushState({}, "", newUrl);
+    debug &&
+      console.debug(
+        `[Routing][window.location] (${label}): Hash Push`,
+        `#${toPath}`
+      );
   }
 };


### PR DESCRIPTION
- Use History API instead of direct hash manipulation to avoid triggering hashchange events
- Add conditional setLayersIdle dispatch to prevent unnecessary Redux state changes
- Improve debug logging and TypeScript types in routing utilities
- Optimize hash routing performance by avoiding React Router cascade rerenders