### PR TITLE
cleanup: remove legacy global polyfill from all apps

### DIFF
--- a/apps/topicmaps/e-bikes/src/main.tsx
+++ b/apps/topicmaps/e-bikes/src/main.tsx
@@ -10,9 +10,6 @@ import { gazDataConfig } from "./config/gazData";
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
-if (typeof global === "undefined") {
-  window.global = window;
-}
 root.render(
   <StrictMode>
     <GazDataProvider config={gazDataConfig}>

--- a/apps/topicmaps/ehrenamtskarte/src/main.tsx
+++ b/apps/topicmaps/ehrenamtskarte/src/main.tsx
@@ -9,9 +9,6 @@ import App from "./app/App.jsx";
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
-if (typeof global === "undefined") {
-  window.global = window;
-}
 root.render(
   <StrictMode>
     <GazDataProvider>

--- a/apps/topicmaps/generic/src/main.tsx
+++ b/apps/topicmaps/generic/src/main.tsx
@@ -31,9 +31,6 @@ console.error = (message, ...args) => {
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
-if (typeof global === "undefined") {
-  window.global = window;
-}
 
 function AppWrapper() {
   let { name } = useParams();

--- a/apps/topicmaps/klimaorte/src/main.tsx
+++ b/apps/topicmaps/klimaorte/src/main.tsx
@@ -10,9 +10,6 @@ import { gazDataConfig } from "./config/gazData.js";
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
-if (typeof global === "undefined") {
-  window.global = window;
-}
 root.render(
   <StrictMode>
     <GazDataProvider config={gazDataConfig}>

--- a/apps/topicmaps/kulturstadtplan/src/main.tsx
+++ b/apps/topicmaps/kulturstadtplan/src/main.tsx
@@ -10,9 +10,6 @@ import { gazDataConfig } from "./config/gazData";
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
-if (typeof global === "undefined") {
-  window.global = window;
-}
 root.render(
   <StrictMode>
     <GazDataProvider config={gazDataConfig}>

--- a/apps/topicmaps/luftmessstationen/src/main.tsx
+++ b/apps/topicmaps/luftmessstationen/src/main.tsx
@@ -10,9 +10,6 @@ import { gazDataConfig } from "./config/gazData.js";
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
-if (typeof global === "undefined") {
-  window.global = window;
-}
 root.render(
   <StrictMode>
     <GazDataProvider config={gazDataConfig}>

--- a/apps/topicmaps/stadtplan/src/main.tsx
+++ b/apps/topicmaps/stadtplan/src/main.tsx
@@ -14,9 +14,6 @@ suppressReactCismapErrors();
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
-if (typeof global === "undefined") {
-  window.global = window;
-}
 root.render(
   <StrictMode>
     <GazDataProvider config={gazDataConfig}>

--- a/apps/topicmaps/vorhabenkarte/src/main.tsx
+++ b/apps/topicmaps/vorhabenkarte/src/main.tsx
@@ -10,9 +10,6 @@ import { gazDataConfig } from "./config/gazData";
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
-if (typeof global === "undefined") {
-  window.global = window;
-}
 
 root.render(
   <StrictMode>

--- a/apps/topicmaps/x-and-ride/src/main.tsx
+++ b/apps/topicmaps/x-and-ride/src/main.tsx
@@ -10,9 +10,6 @@ import { gazDataConfig } from "./config/gazData";
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
-if (typeof global === "undefined") {
-  window.global = window;
-}
 root.render(
   <StrictMode>
     <GazDataProvider config={gazDataConfig}>

--- a/apps/wunda/potenzialflaechen/src/main.tsx
+++ b/apps/wunda/potenzialflaechen/src/main.tsx
@@ -12,9 +12,6 @@ import { gazDataConfig } from "./config/gazData.js";
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
-if (typeof global === "undefined") {
-  window.global = window;
-}
 root.render(
   <StrictMode>
     <GazDataProvider config={gazDataConfig}>


### PR DESCRIPTION
## Summary
Remove the legacy `if (typeof global === undefined) { window.global = window; }` polyfill from all main.tsx files across the monorepo.

## Background
This pattern was originally intended to provide Node.js global scope compatibility for older CommonJS modules and bundlers. However, it's no longer needed with:
- Modern bundlers (Vite, Webpack 5+)
- React 18+ 
- Current build configurations

## Changes
Removed the global polyfill from **10 apps**:
- `topicmaps/e-bikes`
- `topicmaps/ehrenamtskarte`
- `topicmaps/generic`
- `topicmaps/klimaorte`
- `topicmaps/kulturstadtplan`
- `topicmaps/luftmessstationen`
- `topicmaps/stadtplan`
- `topicmaps/vorhabenkarte`
- `topicmaps/x-and-ride`
- `wunda/potenzialflaechen`

## Verification
- All affected apps continue to build and run correctly
- No functional changes - this is pure cleanup
- Consistent with apps that never had this polyfill

## Impact
- **Zero breaking changes** - this polyfill was redundant
- **Cleaner codebase** - removes unnecessary legacy code
- **Consistent patterns** - aligns with modern React practices