### PR TITLE
olb mode can set flyto elevation for search result handling now

### DIFF
--- a/apps/geoportal/src/app/oblique/components/ObliqueProvider.tsx
+++ b/apps/geoportal/src/app/oblique/components/ObliqueProvider.tsx
@@ -11,6 +11,8 @@ import debounce from "lodash/debounce";
 
 import type { FeatureCollection, Polygon } from "geojson";
 
+import { useSelection } from "@carma-appframeworks/portals";
+
 import { useHashState } from "@carma-providers/hash-state";
 
 import type { Radians } from "@carma/geo/types";
@@ -104,6 +106,7 @@ export const ObliqueProvider: React.FC<ObliqueProviderProps> = ({
   fallbackDirectionConfig,
 }) => {
   const { isViewerReady, requestRender } = useCesiumContext();
+  const { selectionFlyToCameraHeightRef } = useSelection();
   const { updateHash, getHashValues } = useHashState();
   // Read initial oblique mode from hash only once on mount
   const [isObliqueMode, setIsObliqueMode] = useState<boolean>(() => {
@@ -131,6 +134,13 @@ export const ObliqueProvider: React.FC<ObliqueProviderProps> = ({
     footprintsStyle,
     imagePreviewStyle,
   } = config;
+
+  useEffect(() => {
+    selectionFlyToCameraHeightRef.current = isObliqueMode ? fixedHeight : null;
+    return () => {
+      selectionFlyToCameraHeightRef.current = null;
+    };
+  }, [fixedHeight, isObliqueMode, selectionFlyToCameraHeightRef]);
 
   const converter = useMemo(() => createConverter(crs, "EPSG:4326"), [crs]);
 

--- a/libraries/appframeworks/portals/src/lib/components/SelectionProvider.tsx
+++ b/libraries/appframeworks/portals/src/lib/components/SelectionProvider.tsx
@@ -3,8 +3,10 @@ import {
   useCallback,
   useContext,
   useMemo,
+  useRef,
   useState,
 } from "react";
+import type { MutableRefObject } from "react";
 import type { Feature } from "geojson";
 
 import { type SearchResultItem } from "@carma/types";
@@ -29,6 +31,7 @@ interface SelectionContextType {
   // todo Include overlay in selectionItme
   overlayFeature: Feature | null;
   setOverlayFeature: (feature: Feature | null) => void;
+  selectionFlyToCameraHeightRef: MutableRefObject<number | null>;
 }
 
 const SelectionContext = createContext<SelectionContextType | undefined>(
@@ -51,6 +54,7 @@ interface SelectionProviderProps {
 export function SelectionProvider({ children }: SelectionProviderProps) {
   const [selection, setSelection] = useState<SelectionItem | null>(null);
   const [overlayFeature, setOverlayFeature] = useState<Feature | null>(null);
+  const selectionFlyToCameraHeightRef = useRef<number | null>(null);
 
   const checkedSetSelection = useCallback(
     (newSelection: SelectionItem | null) => {
@@ -71,6 +75,7 @@ export function SelectionProvider({ children }: SelectionProviderProps) {
       setSelection: checkedSetSelection,
       overlayFeature,
       setOverlayFeature,
+      selectionFlyToCameraHeightRef,
     }),
     [selection, checkedSetSelection, overlayFeature, setOverlayFeature]
   );

--- a/libraries/appframeworks/portals/src/lib/hooks/useSelectionCesium.ts
+++ b/libraries/appframeworks/portals/src/lib/hooks/useSelectionCesium.ts
@@ -124,7 +124,7 @@ export const useSelectionCesium = (
   const { isValidViewer, getScene, getSurfaceProvider, getTerrainProvider } =
     useCesiumContext();
 
-  const { selection } = useSelection();
+  const { selection, selectionFlyToCameraHeightRef } = useSelection();
   const lastSelectionKeyRef = useRef<number | null>(null);
   const lastSelectionTimestampRef = useRef<number | null>(null);
   const shouldAddSelectionInCesiumRef = useRef<boolean>(false);
@@ -278,6 +278,7 @@ export const useSelectionCesium = (
         durationFactor,
         skipFlyTo,
         skipMarkerUpdate,
+        flyToCameraHeight: selectionFlyToCameraHeightRef.current,
       };
 
       if (polygon) {
@@ -342,5 +343,6 @@ export const useSelectionCesium = (
     duration,
     durationFactor,
     selectedMarkerData,
+    selectionFlyToCameraHeightRef,
   ]);
 };

--- a/libraries/appframeworks/portals/src/lib/utils/cesium-handle-area-selection.ts
+++ b/libraries/appframeworks/portals/src/lib/utils/cesium-handle-area-selection.ts
@@ -2,7 +2,6 @@ import {
   BoundingSphere,
   Cartesian3,
   Cartographic,
-  CesiumTerrainProvider,
   ClassificationType,
   Color,
   ColorGeometryInstanceAttribute,
@@ -11,8 +10,8 @@ import {
   HeadingPitchRange,
   PerspectiveFrustum,
   PolygonGeometry,
-  Scene,
-} from "cesium";
+} from "@carma/cesium";
+import type { CesiumTerrainProvider, Scene } from "@carma/cesium";
 
 import {
   getElevationAsync,
@@ -136,9 +135,10 @@ const handlePolygonSelection = (
 
   // Always handle flyTo logic (independent of marker update)
   if (!skipFlyTo) {
+    const height = groundPosition?.height;
     const boundingSphere = getBoundingSphereFromCoordinatesAndHeight(
       polygon[0],
-      groundPosition?.height
+      height
     );
 
     const fullViewDistance = getFullViewDistance(scene, boundingSphere);

--- a/libraries/appframeworks/portals/src/lib/utils/cesium-handle-point-selection.ts
+++ b/libraries/appframeworks/portals/src/lib/utils/cesium-handle-point-selection.ts
@@ -2,18 +2,17 @@ import {
   BoundingSphere,
   Cartesian3,
   Cartographic,
-  CesiumTerrainProvider,
-  EasingFunction,
-  Scene,
+  HeadingPitchRange,
   defined,
-  type Model,
-} from "cesium";
+} from "@carma/cesium";
+import type { CesiumTerrainProvider, Model, Scene } from "@carma/cesium";
+
+import { Easing } from "@carma-commons/math";
 
 import {
   addCesiumMarker,
   distanceFromZoomLevel,
   getElevationAsync,
-  getHeadingPitchRangeFromHeight,
   getHeadingPitchRangeFromZoom,
   removeCesiumMarker,
   type MarkerPrimitiveData,
@@ -86,6 +85,7 @@ const cesiumLookAtPoint = async (
     maxDuration?: number;
     durationFactor?: number;
     useCameraHeight?: boolean;
+    flyToCameraHeight?: number | null;
   } = {}
 ) => {
   // Use camera position directly instead of picking from scene
@@ -104,15 +104,36 @@ const cesiumLookAtPoint = async (
   const cameraCartographic = scene.camera.positionCartographic;
   const currentRange = cameraCartographic.height;
 
-  const hpr = getHeadingPitchRangeFromZoom(zoom - 1, scene.camera);
-  const range = distanceFromZoomLevel(zoom - 2);
+  const heading = scene.camera.heading;
+  const pitch = scene.camera.pitch;
+
+  const flyToCameraHeight = options.flyToCameraHeight;
+
+  let hpr: HeadingPitchRange;
+  let range: number;
+  let sphere: BoundingSphere;
+
+  if (flyToCameraHeight != null) {
+    // Override resulting camera elevation only.
+    // Keep target/ground elevation unchanged.
+    const targetHeight = targetPosition.height;
+    const vertical = Math.max(1, flyToCameraHeight - targetHeight);
+    const sinPitchDown = Math.max(1e-3, -Math.sin(pitch));
+    range = vertical / sinPitchDown;
+    hpr = new HeadingPitchRange(heading, pitch, range);
+    sphere = new BoundingSphere(center, 0);
+  } else {
+    // Default behavior: derive range from zoom and keep heading/pitch from current camera.
+    hpr = getHeadingPitchRangeFromZoom(zoom - 1, scene.camera);
+    range = distanceFromZoomLevel(zoom - 2);
+    sphere = new BoundingSphere(center, range);
+  }
 
   // TODO ADD TEST FOR DURATION FACTOR
+  const denom = Math.max(1, Math.abs(currentRange));
   duration =
-    Math.pow(
-      distanceTargets + Math.abs(currentRange - range) / currentRange,
-      1 / 3
-    ) * (options.durationFactor ?? 1);
+    Math.pow(distanceTargets + Math.abs(currentRange - range) / denom, 1 / 3) *
+    (options.durationFactor ?? 1);
 
   console.info(
     "[CESIUM|SEARCH|CAMERA] move duration",
@@ -131,12 +152,12 @@ const cesiumLookAtPoint = async (
 
   //TODO optional add responsive duration based on distance of target
 
-  scene.camera.flyToBoundingSphere(new BoundingSphere(center, range), {
+  scene.camera.flyToBoundingSphere(sphere, {
     offset: hpr,
     duration,
     pitchAdjustHeight:
       cesiumConfig.pitchAdjustHeight ?? DEFAULT_CESIUM_PITCH_ADJUST_HEIGHT,
-    easingFunction: EasingFunction.QUADRATIC_IN_OUT,
+    easingFunction: Easing.QUADRATIC_IN_OUT,
     complete: () => {
       console.info("[CESIUM|ANIMATION] FlytoBoundingSphere Complete", center);
       options.onComplete && options.onComplete();
@@ -222,6 +243,7 @@ export const cesiumHandlePointSelection = async (
       },
       durationFactor,
       maxDuration: duration,
+      flyToCameraHeight: options.flyToCameraHeight ?? null,
     });
     console.debug(
       "GAZETTEER: [2D3D|CESIUM|CAMERA] look at Marker (Terrain Elevation)"

--- a/libraries/appframeworks/portals/src/lib/utils/cesium-selection-types.ts
+++ b/libraries/appframeworks/portals/src/lib/utils/cesium-selection-types.ts
@@ -8,4 +8,5 @@ export type HitTriggerOptions = {
   invertedSelectedPolygonId?: string;
   skipFlyTo?: boolean;
   skipMarkerUpdate?: boolean;
+  flyToCameraHeight?: number | null;
 };


### PR DESCRIPTION
- elevation does not change for poi targets now.
- for area targets the behavior stays the same to establish an overview first before the olb limiter corrects the elevation after the animation ends.

```
deploy: ["geoportal"]
```