### PR TITLE
Draft: Improve Cesium active tileset readiness handling

### DIFF
--- a/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
+++ b/apps/geoportal/src/app/components/GeoportalMap/GeoportalMap.tsx
@@ -263,6 +263,7 @@ const GeoportalMapInner = ({ height, width, allow3d }: MapProps) => {
     getScene,
     isValidViewer: isValidViewerCtx,
     isViewerReady,
+    tilesetsReady,
     initialViewApplied,
   } = useCesiumContext();
 
@@ -555,8 +556,9 @@ const GeoportalMapInner = ({ height, width, allow3d }: MapProps) => {
     useCesiumNavigationBridge({
       id: GEOPORTAL_CESIUM_VIEW_ADAPTER_ID,
       scene: cesiumScene,
-      isSyncEnabled: Boolean(cesiumScene),
-      isCommitEnabled: isCesium && !getIsTransitioning() && initialViewApplied,
+      isSyncEnabled: Boolean(cesiumScene && initialViewApplied && tilesetsReady),
+      isCommitEnabled:
+        isCesium && !getIsTransitioning() && initialViewApplied && tilesetsReady,
     });
   useGeoportalCesiumNavigationRestore({
     scene: cesiumScene,

--- a/apps/geoportal/src/app/oblique/hooks/useObliqueInitializer.ts
+++ b/apps/geoportal/src/app/oblique/hooks/useObliqueInitializer.ts
@@ -21,6 +21,7 @@ export function useObliqueInitializer(debug = false) {
     getScene,
     sceneAnimationMapRef,
     initialViewApplied,
+    tilesetsReady,
   } = useCesiumContext();
   const { isTransitioning } = useMapFrameworkSwitcherContext();
   const {
@@ -37,6 +38,7 @@ export function useObliqueInitializer(debug = false) {
 
   // Derived scene ref for useCesiumCameraForceOblique
   const sceneRef = useRef<Scene | null>(null);
+  const lastAppliedObliqueModeRef = useRef<boolean | null>(null);
   const scene = getScene();
   sceneRef.current = scene;
 
@@ -88,12 +90,21 @@ export function useObliqueInitializer(debug = false) {
     // Always set the zoom handler state based on oblique mode; the hook will defer attaching until a viewer exists
     setWheelZoomEnabled(isObliqueMode);
 
-    if (!initialViewApplied) {
+    if (!initialViewApplied || !tilesetsReady) {
       return;
     }
 
     const scene = getScene();
     if (scene) {
+      const previousObliqueMode = lastAppliedObliqueModeRef.current;
+      lastAppliedObliqueModeRef.current = isObliqueMode;
+
+      if (!isObliqueMode && previousObliqueMode !== true) {
+        disableCameraForceOblique();
+        setSuspendSelectionSearch(false);
+        return;
+      }
+
       const requestRender = (opts?: { delay?: number; repeat?: number }) =>
         handleDelayedRender(() => scene.requestRender(), opts);
 
@@ -161,6 +172,7 @@ export function useObliqueInitializer(debug = false) {
     debug,
     isObliqueMode,
     initialViewApplied,
+    tilesetsReady,
     // ctx, // intentionally omitted to prevent re-triggering on context changes
     getScene,
     fixedPitch,

--- a/libraries/mapping/engines/cesium/legacy/src/lib/CesiumContext.tsx
+++ b/libraries/mapping/engines/cesium/legacy/src/lib/CesiumContext.tsx
@@ -21,6 +21,11 @@ export interface CesiumContextType {
   isViewerReady: boolean;
   setIsViewerReady: (flag: boolean) => void;
   providersReady: boolean;
+  primaryTilesetConfigured: boolean;
+  secondaryTilesetConfigured: boolean;
+  tilesetsReady: boolean;
+  setPrimaryTilesetReady: (flag: boolean) => void;
+  setSecondaryTilesetReady: (flag: boolean) => void;
   // Track when initial camera view from URL has been applied
   initialViewApplied: boolean;
   setInitialViewApplied: (flag: boolean) => void;

--- a/libraries/mapping/engines/cesium/legacy/src/lib/CesiumContextProvider.tsx
+++ b/libraries/mapping/engines/cesium/legacy/src/lib/CesiumContextProvider.tsx
@@ -37,6 +37,9 @@ export const CesiumContextProvider = ({
   providerConfig: ProviderConfig;
   tilesetConfigs: TilesetConfigs;
 }) => {
+  const primaryTilesetConfigured = Boolean(tilesetConfigs.primary);
+  const secondaryTilesetConfigured = Boolean(tilesetConfigs.secondary);
+
   // Use refs for Cesium instances to prevent re-renders
   const viewerRef = useRef<Viewer | null>(null);
   const sceneAnimationMapRef = useRef<SceneAnimationMap | null>(
@@ -56,6 +59,13 @@ export const CesiumContextProvider = ({
   const [isViewerReady, setIsViewerReady] = useState<boolean>(false);
   // Track when initial camera view from URL has been applied
   const [initialViewApplied, setInitialViewApplied] = useState<boolean>(false);
+  const [primaryTilesetReady, setPrimaryTilesetReady] = useState<boolean>(
+    !primaryTilesetConfigured
+  );
+  const [secondaryTilesetReady, setSecondaryTilesetReady] = useState<boolean>(
+    !secondaryTilesetConfigured
+  );
+  const tilesetsReady = primaryTilesetReady && secondaryTilesetReady;
 
   const getScene = useCallback((): Scene | null => {
     if (viewerRef.current) {
@@ -118,30 +128,40 @@ export const CesiumContextProvider = ({
 
   // Load Primary Tileset
   useEffect(() => {
-    let cancelled = false;
-    if (tilesetConfigs.primary && isViewerReady) {
-      const fetchPrimary = async () => {
-        console.debug(
-          "[CESIUM|DEBUG] Loading primary tileset",
-          tilesetConfigs.primary
-        );
-        const tileset = await loadTileset(tilesetConfigs.primary);
-        if (cancelled) {
-          if (!tileset.isDestroyed()) {
-            tileset.destroy();
-          }
-          return;
-        }
-        primaryTilesetRef.current = tileset;
-        console.debug(
-          "[CESIUM|DEBUG] Loaded primary tileset",
-          primaryTilesetRef.current
-        );
-      };
-      fetchPrimary().catch(console.error);
-    } else {
+    if (!tilesetConfigs.primary) {
+      setPrimaryTilesetReady(true);
       console.debug("[CESIUM|DEBUG] No primary tileset configured");
+      return;
     }
+    if (!isViewerReady) {
+      setPrimaryTilesetReady(false);
+      return;
+    }
+
+    let cancelled = false;
+    const tilesetConfig = tilesetConfigs.primary;
+    setPrimaryTilesetReady(false);
+    const fetchPrimary = async () => {
+      console.debug("[CESIUM|DEBUG] Loading primary tileset", tilesetConfig);
+      const tileset = await loadTileset(tilesetConfig);
+      if (cancelled) {
+        if (!tileset.isDestroyed()) {
+          tileset.destroy();
+        }
+        return;
+      }
+      primaryTilesetRef.current = tileset;
+      console.debug(
+        "[CESIUM|DEBUG] Loaded primary tileset",
+        primaryTilesetRef.current
+      );
+    };
+    fetchPrimary().catch((error) => {
+      console.error(error);
+      if (!cancelled) {
+        setPrimaryTilesetReady(false);
+      }
+    });
 
     return () => {
       cancelled = true;
@@ -157,30 +177,40 @@ export const CesiumContextProvider = ({
 
   // Load Secondary Tileset
   useEffect(() => {
-    let cancelled = false;
-    if (tilesetConfigs.secondary && isViewerReady && isValidViewer()) {
-      const fetchSecondary = async () => {
-        console.debug(
-          "[CESIUM|DEBUG] Loading secondary tileset",
-          tilesetConfigs.secondary
-        );
-        const tileset = await loadTileset(tilesetConfigs.secondary!);
-        if (cancelled) {
-          if (!tileset.isDestroyed()) {
-            tileset.destroy();
-          }
-          return;
-        }
-        secondaryTilesetRef.current = tileset;
-        console.debug(
-          "[CESIUM|DEBUG] Loaded secondary tileset",
-          secondaryTilesetRef.current
-        );
-      };
-      fetchSecondary().catch(console.error);
-    } else {
+    if (!tilesetConfigs.secondary) {
+      setSecondaryTilesetReady(true);
       console.debug("[CESIUM|DEBUG] No secondary tileset configured");
+      return;
     }
+    if (!isViewerReady || !isValidViewer()) {
+      setSecondaryTilesetReady(false);
+      return;
+    }
+
+    let cancelled = false;
+    const tilesetConfig = tilesetConfigs.secondary;
+    setSecondaryTilesetReady(false);
+    const fetchSecondary = async () => {
+      console.debug("[CESIUM|DEBUG] Loading secondary tileset", tilesetConfig);
+      const tileset = await loadTileset(tilesetConfig);
+      if (cancelled) {
+        if (!tileset.isDestroyed()) {
+          tileset.destroy();
+        }
+        return;
+      }
+      secondaryTilesetRef.current = tileset;
+      console.debug(
+        "[CESIUM|DEBUG] Loaded secondary tileset",
+        secondaryTilesetRef.current
+      );
+    };
+    fetchSecondary().catch((error) => {
+      console.error(error);
+      if (!cancelled) {
+        setSecondaryTilesetReady(false);
+      }
+    });
 
     return () => {
       cancelled = true;
@@ -219,6 +249,11 @@ export const CesiumContextProvider = ({
       setIsViewerReady,
       setInitialViewApplied,
       providersReady,
+      primaryTilesetConfigured,
+      secondaryTilesetConfigured,
+      tilesetsReady,
+      setPrimaryTilesetReady,
+      setSecondaryTilesetReady,
       initialViewApplied,
       isViewerReady,
       // NOTE: Workaround for CesiumGS/cesium#12543 — delay/repeat options exist
@@ -235,6 +270,9 @@ export const CesiumContextProvider = ({
       isViewerReady,
       initialViewApplied,
       providersReady,
+      primaryTilesetConfigured,
+      secondaryTilesetConfigured,
+      tilesetsReady,
       requestRender,
       instanceCallbacks,
     ]

--- a/libraries/mapping/engines/cesium/legacy/src/lib/hooks/useTilesets.ts
+++ b/libraries/mapping/engines/cesium/legacy/src/lib/hooks/useTilesets.ts
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import { useSelector } from "react-redux";
 
+import type { Cesium3DTileset, Scene } from "@carma-cesium";
+
 import {
   selectShowPrimaryTileset,
   selectShowSecondaryTileset,
@@ -9,16 +11,82 @@ import { guardScene } from "../utils/guardScene";
 import { guardTileset } from "../utils/guardTileset";
 import { useCesiumContext } from "./useCesiumContext";
 import { useSecondaryStyleTilesetClickHandler } from "./useSecondaryStyleTilesetClickHandler";
+
+const waitForVisibleTilesetViewTiles = (
+  scene: Scene,
+  tileset: Cesium3DTileset,
+  setReady: (ready: boolean) => void,
+  label: string
+): (() => void) => {
+  setReady(false);
+
+  let disposed = false;
+  let removeAllTilesLoadedListener: (() => void) | undefined;
+  let removePostRenderListener: (() => void) | undefined;
+
+  const cleanup = () => {
+    removeAllTilesLoadedListener?.();
+    removePostRenderListener?.();
+    removeAllTilesLoadedListener = undefined;
+    removePostRenderListener = undefined;
+  };
+
+  const markReady = () => {
+    if (disposed) return;
+    setReady(true);
+    cleanup();
+  };
+  const checkRenderedView = () => {
+    if (disposed || tileset.isDestroyed()) return;
+    if (tileset.tilesLoaded) {
+      markReady();
+    }
+  };
+
+  tileset.allTilesLoaded.addEventListener(markReady);
+  removeAllTilesLoadedListener = () =>
+    tileset.allTilesLoaded.removeEventListener(markReady);
+  scene.postRender.addEventListener(checkRenderedView);
+  removePostRenderListener = () =>
+    scene.postRender.removeEventListener(checkRenderedView);
+  scene.requestRender();
+
+  return () => {
+    disposed = true;
+    cleanup();
+    console.debug(`[CESIUM|DEBUG] Cancelled ${label} tileset ready wait`);
+  };
+};
+
 export const useTilesets = () => {
   const showPrimary = useSelector(selectShowPrimaryTileset);
-  const ctx = useCesiumContext();
   const showSecondary = useSelector(selectShowSecondaryTileset);
+  const {
+    withPrimaryTileset,
+    withSecondaryTileset,
+    requestRender,
+    setPrimaryTilesetReady,
+    setSecondaryTilesetReady,
+    initialViewApplied,
+    primaryTilesetConfigured,
+    secondaryTilesetConfigured,
+  } = useCesiumContext();
 
   useEffect(() => {
-    let added = false;
+    let cancelled = false;
+    let removeReadyListener: (() => void) | null = null;
+    const waitForCurrentView = showPrimary && initialViewApplied;
+
+    if (!primaryTilesetConfigured) {
+      setPrimaryTilesetReady(true);
+      return;
+    }
+    setPrimaryTilesetReady(!showPrimary);
+
     const repeatUntilAdded = () => {
-      if (added) return;
-      const has = ctx.withPrimaryTileset((tileset, viewer) => {
+      if (cancelled) return;
+      const has = withPrimaryTileset((tileset, viewer) => {
+        if (cancelled) return;
         const contains = guardScene(
           viewer.scene,
           "useTilesets-primary"
@@ -29,7 +97,19 @@ export const useTilesets = () => {
           );
         }
         guardTileset(tileset, "useTilesets-primary").show(showPrimary);
-        added = true;
+
+        removeReadyListener?.();
+        removeReadyListener = waitForCurrentView
+          ? waitForVisibleTilesetViewTiles(
+              viewer.scene,
+              tileset,
+              setPrimaryTilesetReady,
+              "primary"
+            )
+          : null;
+        if (!waitForCurrentView) {
+          setPrimaryTilesetReady(!showPrimary);
+        }
       });
       if (!has) {
         // not yet available -> retry next frame
@@ -37,14 +117,36 @@ export const useTilesets = () => {
       }
     };
     repeatUntilAdded();
-    ctx.requestRender();
-  }, [ctx, showPrimary]);
+    requestRender();
+
+    return () => {
+      cancelled = true;
+      removeReadyListener?.();
+    };
+  }, [
+    initialViewApplied,
+    primaryTilesetConfigured,
+    requestRender,
+    setPrimaryTilesetReady,
+    showPrimary,
+    withPrimaryTileset,
+  ]);
 
   useEffect(() => {
-    let added = false;
+    let cancelled = false;
+    let removeReadyListener: (() => void) | null = null;
+    const waitForCurrentView = showSecondary && initialViewApplied;
+
+    if (!secondaryTilesetConfigured) {
+      setSecondaryTilesetReady(true);
+      return;
+    }
+    setSecondaryTilesetReady(!showSecondary);
+
     const repeatUntilAdded = () => {
-      if (added) return;
-      const has = ctx.withSecondaryTileset((tileset, viewer) => {
+      if (cancelled) return;
+      const has = withSecondaryTileset((tileset, viewer) => {
+        if (cancelled) return;
         const contains = guardScene(
           viewer.scene,
           "useTilesets-secondary"
@@ -55,42 +157,66 @@ export const useTilesets = () => {
           );
         }
         guardTileset(tileset, "useTilesets-secondary").show(showSecondary);
-        added = true;
+
+        removeReadyListener?.();
+        removeReadyListener = waitForCurrentView
+          ? waitForVisibleTilesetViewTiles(
+              viewer.scene,
+              tileset,
+              setSecondaryTilesetReady,
+              "secondary"
+            )
+          : null;
+        if (!waitForCurrentView) {
+          setSecondaryTilesetReady(!showSecondary);
+        }
       });
       if (!has) {
         requestAnimationFrame(repeatUntilAdded);
       }
     };
     repeatUntilAdded();
-    ctx.requestRender();
-  }, [ctx, showSecondary]);
+    requestRender();
+
+    return () => {
+      cancelled = true;
+      removeReadyListener?.();
+    };
+  }, [
+    initialViewApplied,
+    requestRender,
+    secondaryTilesetConfigured,
+    setSecondaryTilesetReady,
+    showSecondary,
+    withSecondaryTileset,
+  ]);
 
   useEffect(() => {
     console.debug("HOOK BaseTilesets: showSecondary", showSecondary);
-    ctx.withSecondaryTileset((tileset) => {
+    withSecondaryTileset((tileset) => {
       guardTileset(tileset, "useTilesets-secondary").show(showSecondary);
-      ctx.requestRender();
+      requestRender();
     });
-  }, [ctx, showSecondary]);
+  }, [requestRender, showSecondary, withSecondaryTileset]);
 
   useEffect(() => {
     console.debug("HOOK BaseTilesets: showPrimary", showPrimary);
-    ctx.withPrimaryTileset((tileset) => {
+    withPrimaryTileset((tileset) => {
       guardTileset(tileset, "useTilesets-primary").show(showPrimary);
-      ctx.requestRender();
+      requestRender();
     });
-  }, [ctx, showPrimary]);
+  }, [requestRender, showPrimary, withPrimaryTileset]);
 
   useSecondaryStyleTilesetClickHandler();
 
   useEffect(() => {
     // Show/hide tilesets based on style selection
     // Parent controls when Cesium is visible, not this hook
-    ctx.withPrimaryTileset((tileset) =>
+    withPrimaryTileset((tileset) =>
       guardTileset(tileset, "useTilesets-primary").show(showPrimary)
     );
-    ctx.withSecondaryTileset((tileset) =>
+    withSecondaryTileset((tileset) =>
       guardTileset(tileset, "useTilesets-secondary").show(showSecondary)
     );
-  }, [ctx, showPrimary, showSecondary]);
+  }, [showPrimary, showSecondary, withPrimaryTileset, withSecondaryTileset]);
 };

--- a/libraries/mapping/engines/cesium/legacy/src/lib/utils/cesiumTilesetProviders.ts
+++ b/libraries/mapping/engines/cesium/legacy/src/lib/utils/cesiumTilesetProviders.ts
@@ -10,7 +10,17 @@ export type TilesetConfigs = {
 
 const MESH_SHADER = CUSTOM_SHADERS_DEFINITIONS.UNLIT_ENHANCED_2024;
 
+const BYTES_PER_MIB = 1024 * 1024;
+const FOUR_GB_DEVICE_TILESET_CACHE_OPTIONS: Pick<
+  Cesium3DTileset.ConstructorOptions,
+  "cacheBytes" | "maximumCacheOverflowBytes"
+> = {
+  cacheBytes: 4096 * BYTES_PER_MIB,
+  maximumCacheOverflowBytes: 2048 * BYTES_PER_MIB,
+};
+
 const DEFAULT_MESH_OPTIONS: Cesium3DTileset.ConstructorOptions = {
+  ...FOUR_GB_DEVICE_TILESET_CACHE_OPTIONS,
   preloadWhenHidden: false,
   shadows: ShadowMode.DISABLED,
   enableCollision: false,
@@ -35,6 +45,7 @@ const DEFAULT_MESH_OPTIONS: Cesium3DTileset.ConstructorOptions = {
 };
 
 const DEFAULT_LOD2_OPTIONS: Cesium3DTileset.ConstructorOptions = {
+  ...FOUR_GB_DEVICE_TILESET_CACHE_OPTIONS,
   maximumScreenSpaceError: 4,
   dynamicScreenSpaceError: false,
   foveatedScreenSpaceError: true,
@@ -44,8 +55,8 @@ const DEFAULT_LOD2_OPTIONS: Cesium3DTileset.ConstructorOptions = {
 
 const loadLOD2Tileset = async (tileset: TilesetConfig) => {
   const lod2Options = {
-    ...tileset.constructorOptions,
     ...DEFAULT_LOD2_OPTIONS,
+    ...tileset.constructorOptions,
   };
   const lod2 = await Cesium3DTileset.fromUrl(tileset.url, lod2Options);
   return lod2;
@@ -55,8 +66,8 @@ const loadMeshTileset = async (tileset: TilesetConfig) => {
   // TODO get shader from tileset config
   const shader = new CustomShader(MESH_SHADER);
   const meshOptions = {
-    ...tileset.constructorOptions,
     ...DEFAULT_MESH_OPTIONS,
+    ...tileset.constructorOptions,
   };
   const mesh = await Cesium3DTileset.fromUrl(tileset.url, meshOptions);
   mesh.customShader = shader;


### PR DESCRIPTION
Refs #681

Draft PR for the Cesium tileset-readiness work that was split out of the current Geoportal hash/measurement-mode changes.

Scope currently captured in this branch:

- WIP readiness tracking around Cesium tilesets.
- Gating of scene-center consumers such as Geoportal navigation bridge and oblique initialization.
- Tileset cache/default handling that should be tested separately from reload/hash fixes.

Important review note:

The current WIP API is intentionally not final. It should be redesigned around active/relevant tileset readiness rather than exposing fixed primary/secondary tileset slot flags through the public Cesium context.

Validation:

- Not rerun after extraction.
- This draft should receive its own focused reload, layer-toggle, mesh/LOD2 and deployment parity validation before it is considered for review.